### PR TITLE
Have saved prefida input be named <runid>_inputs.(json|pro|sav) depending on input type

### DIFF
--- a/prefida.pro
+++ b/prefida.pro
@@ -1006,7 +1006,7 @@ PRO prefida,input_file,input_str=input_str,plot=plot,save=save
     CASE input_type OF
         'FILE':begin
             file_path=input_file
-            file_name=FILE_BASENAME(input_file)
+            file_name=inputs.runid+'_inputs.json'
             FILE_COPY,file_path,$
               inputs.result_dir+'/'+file_name,$
               /overwrite,/allow_same
@@ -1014,13 +1014,13 @@ PRO prefida,input_file,input_str=input_str,plot=plot,save=save
         'PROCEDURE':begin
             file_info=ROUTINE_INFO(input_file,/source)
             file_path=file_info.path
-            file_name=input_file+'.pro'
+            file_name=inputs.runid+'_inputs.pro'
             FILE_COPY,file_path,$
               inputs.result_dir+'/'+file_name,$
               /overwrite,/allow_same
             end
         'STRUCTURE':begin
-            file_name=inputs.result_dir+'/inputs_str.sav'
+            file_name=inputs.result_dir+'/'+inputs.runid+'_inputs.sav'
             save,inputs,filename=file_name
             end
     ENDCASE


### PR DESCRIPTION
@bgrierson21
As discussed in todays meeting this should fix the problem of over writing the saved prefida inputs. 

I decided against simply adding a number identifier since there may be cases where we have to rerun prefida with the same RUNID. We don't want i.e. ```d3d_input.pro, d3d_input1.pro,d3d_input2.pro``` when they are exactly the same file. 

Instead this standardizes the filenames to be ```<runid>_inputs.(json|pro|sav)```. Prefida will overwrite theses file but I think it should. The RUNID should represent a unique set of inputs. If you are using the same RUNID that would imply that the old set of inputs was incorrect in some way and needed replacing.  

Are there any issues with this approach?