### PR TITLE
Files ending in ~ caused extract_transp_fbm to fail.

### DIFF
--- a/LIB/extract_geqdsk
+++ b/LIB/extract_geqdsk
@@ -83,7 +83,8 @@ def main():
 
     for time in times:
         if not args.gfile:
-            gfile = 'g'+re.match('^\d+',args.runid).group(0)+'.00'+str(long(round(time*1000.)))
+			time_str = str(long(round(time*1000.)))
+            gfile = 'g'+re.match('^\d+',args.runid).group(0)+'.'+'0'*(5-len(time_str))+time_str
         gfile = args.output_dir+'/'+gfile
 
         args_dict = {'runid':args.runid,'time':time, 'dt':args.delta_time,

--- a/LIB/extract_transp_fbm
+++ b/LIB/extract_transp_fbm
@@ -35,7 +35,7 @@ def main():
 
     if not fileid_list:
        file_list = glob.glob(args.path+'/'+args.runid+'.DATA*')
-       fileid_list=[re.match('.*?([0-9]+)$',s).group(1) for s in file_list]
+       fileid_list=list(set([re.match('.*?([0-9]+)~?$',s).group(1) for s in file_list]))
 
     for id in fileid_list:
        args_dict = {'rid':args.runid,'path':args.path,


### PR DESCRIPTION
Sometimes TRANSP's data files i.e. ```159247H12.DATA1``` had a ```~``` appended onto the end e.g. ``159247H12.DATA1~```.  Both files ```159247H12.DATA1``` and ```159247H12.DATA1~``` were present in the directory. The tilde caused the regex used to extract the file_id to not find a match. This commit fixes the regex to allow files ending in tilde and also then filters out any repeated file_ids.