### PR TITLE
Protect against dividing by zero in colrad

### DIFF
--- a/fidasim.f90
+++ b/fidasim.f90
@@ -2497,6 +2497,9 @@ contains
     call matinv(eigvec, eigvec_inv)
     coef = matmul(eigvec_inv, states)!coeffs determined from states at t=0
     exp_eigval_dt = exp(eigval*dt)   ! to improve speed (used twice)
+    do n=1,nlevs
+       if(eigval(n).eq.0.0) eigval(n)=eigval(n)+1 !protect against dividing by zero
+    enddo
     states(:) = matmul(eigvec, coef * exp_eigval_dt)  ![neutrals/cm^3/s]!
     dens(:)   = matmul(eigvec,coef*(exp_eigval_dt-1.d0)/eigval)/nlaunch
 


### PR DESCRIPTION
Low densities and temperatures can cause the eigenvalues of rates matrix to be zero i.e. the rate of transfer from one level to another is zero. 
```
    ...
    call eigen(nlevs, matrix, eigvec, eigval) <----------ZERO APPEARS HERE
    ...
    exp_eigval_dt = exp(eigval*dt)   ! to improve speed (used twice)
    dens(:)   = matmul(eigvec,coef*(exp_eigval_dt-1.d0)/eigval)/nlaunch <----------0/0
```

The fix is to just add one to the eigenvalue so that is is non-zero. The effect is to translate the expression  ```coef*(exp_eigval_dt-1.d0)/eigval == 0/0``` to ```coef*(exp_eigval_dt-1.d0)/eigval == 0/1```.

This fix doesn't effect any physics.