### PR TITLE
Fix bug with the simulation switches.

### DIFF
--- a/lib/get_version.pro
+++ b/lib/get_version.pro
@@ -15,7 +15,7 @@ FUNCTION get_version, fidasim_dir
     git_dir = fidasim_dir+'/.git'
     spawn,'command -v git ',git_command,/sh
     if file_test(git_command) and file_test(git_dir,/dir) then begin
-        spawn,git_command+' --git-dir='+git_dir+' describe --tags --always',version,err_status
+        spawn,git_command+' --git-dir='+git_dir+' describe --tags --always --dirty',version,err_status
     endif else begin
         version_file = fidasim_dir+'/VERSION'
         version = ''

--- a/src/makefile
+++ b/src/makefile
@@ -16,7 +16,7 @@ endif
 
 BUILD := $(shell command -v git >/dev/null 2>&1 && \
 	[ -d $(FIDASIM_DIR)/.git ] && \
-	git --git-dir=$(FIDASIM_DIR)/.git describe --tags --always)
+	git --git-dir=$(FIDASIM_DIR)/.git describe --tags --always --dirty)
 
 ifneq ($(BUILD),)
 	UFLAGS = -D_VERSION=\"$(BUILD)\"


### PR DESCRIPTION
Fix bug with the simulation switches. spec_chords%los_inter has to always be set not just when spectra flags are set.

Make `dump_dcx` flag a bit more careful with respect to the other switches.
Add --dirty to git version getting routines. Close #76