### PR TITLE
Add capability to calculate neutron emission rate

### DIFF
--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -1589,15 +1589,6 @@ subroutine read_inputs
     beam_grid%gamma=gamma
     beam_grid%origin=origin
 
-    error = .False.
-
-    inquire(directory=inputs%result_dir,exist=exis)
-    if(.not.exis) then
-        write(*,'(a,a)') 'READ_INPUTS: Result directory does not exist: ', &
-                         trim(inputs%result_dir)
-        error = .True.
-    endif
-
     if(inputs%verbose.ge.1) then
         write(*,'(a)') "---- Shot settings ----"
         write(*,'(T2,"Shot: ",i8)') inputs%shot_number
@@ -1606,6 +1597,8 @@ subroutine read_inputs
         write(*,*) ''
         write(*,'(a)') "---- Input files ----"
     endif
+
+    error = .False.
 
     inquire(file=inputs%tables_file,exist=exis)
     if(exis) then

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -328,6 +328,8 @@ type FastIonDistribution
         !+ Maximum pitch
     real(Float64)  :: p_range
         !+ Pitch interval length
+    real(Float64)  :: n_tot = 0.d0
+        !+ Total Number of fast-ions
     real(Float64), dimension(:), allocatable       :: energy
         !+ Energy values [keV]
     real(Float64), dimension(:), allocatable       :: pitch
@@ -490,6 +492,34 @@ type AtomicRates
         !+ Log-10 reaction rates for de-populating transistions
 end type AtomicRates
 
+type NuclearRates
+    !+ Nuclear reaction rates
+    integer       :: nbranch = 1
+        !+ Number of reaction branches
+    integer       :: nenergy = 1
+        !+ Number of beam energies
+    real(Float64) :: logemin = 0.d0
+        !+ Log-10 minimum energy
+    real(Float64) :: logemax = 0.d0
+        !+ Log-10 maximum energy
+    integer       :: ntemp = 1
+        !+ Number of target temperatures
+    real(Float64) :: logtmin = 0.d0
+        !+ Log-10 minimum temperature
+    real(Float64) :: logtmax = 0.d0
+        !+ Log-10 maximum temperature
+    real(Float64) :: dlogE = 0.d0
+        !+ Log-10 energy spacing
+    real(Float64) :: dlogT = 0.d0
+        !+ Log-10 temperature spacing
+    real(Float64) :: minlog_rate = 0.d0
+        !+ Log-10 minimum reaction rate
+    real(Float64), dimension(2) :: bt_amu = 0.d0
+        !+ Isotope mass of beam and thermal ions respectively [amu]
+    real(Float64), dimension(:,:,:), allocatable :: log_rate
+        !+ Log-10 reaction rates: log_rate(energy, temperature, branch)
+end type NuclearRates
+
 type AtomicTables
     !+ Atomic tables for various types of interactions
     type(AtomicCrossSection) :: H_H_cx
@@ -502,6 +532,8 @@ type AtomicTables
         !+ Hydrogen-Impurity reaction rates
     real(Float64), dimension(nlevs,nlevs) :: einstein
         !+ Einstein coefficients for spontaneous emission
+    type(NuclearRates)       :: D_D
+        !+ Deuterium-Deuterium reaction rates
 end type AtomicTables
 
 type LineOfSight
@@ -558,8 +590,12 @@ type NPAProbability
     !+ Type to contain the probability of hitting a NPA detector
     real(Float64) :: p = 0.d0
         !+ Hit probability
+    real(Float64) :: pitch = -2.d0
+        !+ Pitch
     real(Float64), dimension(3) :: eff_rd = 0.d0
         !+ Effective position of detector
+    real(Float64), dimension(3) :: dir = 0.d0
+        !+ Trajectory direction
 end type NPAProbability
 
 type NPAChords
@@ -610,6 +646,8 @@ type NPAResults
         !+ Maximum allowed number of particles grows if necessary
     integer(Int32) :: nloop = 1000
         !+ Increases number of MC markers by factor of `nloop`
+    integer(Int32) :: nenergy = 100
+        !+ Number of energy values
     type(NPAParticle), dimension(:), allocatable  :: part
         !+ Array of NPA particles
     real(Float64), dimension(:), allocatable      :: energy
@@ -643,6 +681,12 @@ type Spectra
     real(Float64), dimension(:,:,:), allocatable :: fida
         !+ FIDA emission: fida(lambda,chan,orbit_type)
 end type Spectra
+
+type NeutronRate
+    !+ Neutron storage structure
+    real(Float64), dimension(:), allocatable :: rate
+        !+ Neutron rate: rate(orbit_type) [neutrons/sec]
+end type NeutronRate
 
 type NeutralDensity
     !+ Neutral density structure
@@ -727,6 +771,8 @@ type SimulationInputs
         !+ Calculate NPA weights: 0 = off, 1=on, 2=on++
     integer(Int32) :: calc_birth
         !+ Calculate birth profile: 0 = off, 1=on
+    integer(Int32) :: calc_neutron
+        !+ Calculate neutron flux: 0 = off, 1=on
     integer(Int32) :: no_flr
         !+ Turns off Finite Larmor Radius effects: 0=off, 1=on
     integer(Int32) :: dump_dcx
@@ -861,6 +907,8 @@ type(NeutralDensity), save      :: neut
     !+ Variable for storing the calculated beam density
 type(Spectra), save             :: spec
     !+ Variable for storing the calculated spectra
+type(NeutronRate), save         :: neutron
+    !+ Variable for storing the neutron rate
 type(FIDAWeights), save         :: fweight
     !+ Variable for storing the calculated FIDA weights
 type(NPAWeights), save          :: nweight
@@ -1420,7 +1468,7 @@ subroutine read_inputs
     character(charlim) :: runid,result_dir, tables_file
     character(charlim) :: distribution_file, equilibrium_file
     character(charlim) :: geometry_file, neutrals_file
-    integer            :: pathlen
+    integer            :: pathlen, calc_neutron
     integer            :: calc_brems,calc_bes,calc_fida,calc_npa
     integer            :: calc_birth,calc_fida_wght,calc_npa_wght
     integer            :: load_neutrals,verbose,dump_dcx,no_flr
@@ -1439,7 +1487,7 @@ subroutine read_inputs
         geometry_file, equilibrium_file, neutrals_file, shot, time, runid, &
         calc_brems, calc_bes, calc_fida, calc_npa, calc_birth, no_flr, &
         calc_fida_wght, calc_npa_wght, load_neutrals, dump_dcx, verbose, &
-        n_fida,n_npa, n_nbi, n_halo, n_dcx, n_birth, &
+        calc_neutron, n_fida,n_npa, n_nbi, n_halo, n_dcx, n_birth, &
         ab, pinj, einj, current_fractions, ai, impurity_charge, &
         nx, ny, nz, xmin, xmax, ymin, ymax, zmin, zmax, &
         origin, alpha, beta, gamma, &
@@ -1453,8 +1501,9 @@ subroutine read_inputs
         stop
     endif
 
-    !!Set Defaults
+    !!Set Defaults TODO: remove at next major release
     no_flr = 0
+    calc_neutron = 0
 
     open(13,file=namelist_file)
     read(13,NML=fidasim_inputs)
@@ -1486,6 +1535,7 @@ subroutine read_inputs
     inputs%calc_birth=calc_birth
     inputs%calc_fida_wght=calc_fida_wght
     inputs%calc_npa_wght=calc_npa_wght
+    inputs%calc_neutron=calc_neutron
     inputs%load_neutrals=load_neutrals
     inputs%dump_dcx=dump_dcx
     inputs%verbose=verbose
@@ -1922,9 +1972,8 @@ subroutine read_npa
     real(Float64), dimension(3) :: eff_rd, rd, rd_d, r0, r0_d, v0
     real(Float64), dimension(3,3) :: basis, inv_basis
     real(Float64), dimension(50) :: xd, yd
-    real(Float64), dimension(:,:,:,:,:), allocatable :: effrd
-    real(Float64), dimension(:,:,:,:), allocatable :: phit
-    real(Float64) :: total_prob, hh, hw, dprob, dx, dy, r
+    type(LocalEMFields) :: fields
+    real(Float64) :: total_prob, hh, hw, dprob, dx, dy, r, pitch
     integer :: ichan,i,j,k,ix,iy,d_index,nd,cnt
     integer :: error
 
@@ -1976,17 +2025,6 @@ subroutine read_npa
                             beam_grid%ny, &
                             beam_grid%nz) )
     npa_chords%hit = .False.
-
-    allocate(effrd(3,beam_grid%nx,&
-                     beam_grid%ny,&
-                     beam_grid%nz,&
-                     npa_chords%nchan) )
-    allocate(phit(beam_grid%nx,&
-                  beam_grid%ny,&
-                  beam_grid%nz,&
-                  npa_chords%nchan) )
-    effrd = 0.d0
-    phit = 0.d0
 
     dims = [3,spec_chords%nchan]
     call h5ltread_dataset_double_f(gid,"/npa/radius", npa_chords%radius, dims(2:2), error)
@@ -2058,7 +2096,7 @@ subroutine read_npa
         cnt = 0
         ! For each grid point find the probability of hitting the detector given an isotropic source
         !$OMP PARALLEL DO schedule(guided) collapse(3) private(i,j,k,ix,iy,total_prob,eff_rd,r0,r0_d, &
-        !$OMP& rd_d,rd,d_index,v0,dprob,r)
+        !$OMP& rd_d,rd,d_index,v0,dprob,r,fields)
         do k=1,beam_grid%nz
             do j=1,beam_grid%ny
                 do i=1,beam_grid%nx
@@ -2084,9 +2122,11 @@ subroutine read_npa
                     enddo !xd loop
                     if(total_prob.gt.0.0) then
                         eff_rd = eff_rd/total_prob
-                        phit(i,j,k,ichan) = total_prob
-                        call xyz_to_uvw(eff_rd,effrd(:,i,j,k,ichan))
+                        call get_fields(fields,pos=r0)
+                        v0 = (eff_rd - r0)/norm2(eff_rd - r0)
+                        npa_chords%phit(i,j,k,ichan)%pitch = dot_product(fields%b_norm,v0)
                         npa_chords%phit(i,j,k,ichan)%p = total_prob
+                        npa_chords%phit(i,j,k,ichan)%dir = v0
                         npa_chords%phit(i,j,k,ichan)%eff_rd = eff_rd
                         npa_chords%hit(i,j,k) = .True.
                     endif
@@ -2106,9 +2146,9 @@ subroutine read_npa
         endif
 
     enddo chan_loop
+
     if(inputs%verbose.ge.1) write(*,'(50X,a)') ""
 
-    deallocate(phit,effrd)
     deallocate(a_shape,a_cent,a_redge,a_tedge)
     deallocate(d_shape,d_cent,d_redge,d_tedge)
 
@@ -2158,7 +2198,7 @@ subroutine read_equilibrium
         write(*,'(a)') '---- Interpolation grid settings ----'
         write(*,'(T2,"Nr: ",i3)') inter_grid%nr
         write(*,'(T2,"Nz: ",i3)') inter_grid%nz
-        write(*,'(T2,"dA: ", f4.2," [cm^2]")') inter_grid%da
+        write(*,'(T2,"dA: ", f5.2," [cm^2]")') inter_grid%da
         write(*,*) ''
     endif
 
@@ -2239,6 +2279,7 @@ subroutine read_f(fid, error)
 
     integer(HSIZE_T), dimension(4) :: dims
     real(Float64) :: dummy(1)
+    integer :: ir
 
     if(inputs%verbose.ge.1) then
         write(*,'(a)') '---- Fast-ion distribution settings ----'
@@ -2283,12 +2324,17 @@ subroutine read_f(fid, error)
     fbm%pmax = dummy(1)
     fbm%p_range = fbm%pmax - fbm%pmin
 
+    do ir=1,fbm%nr
+        fbm%n_tot = fbm%n_tot + 2*pi*fbm%dr*fbm%dz*sum(fbm%denf(ir,:))*fbm%r(ir)
+    enddo
+
     if(inputs%verbose.ge.1) then
         write(*,'(T2,"Distribution type: ",a)') "Fast-ion Density Function F(energy,pitch,R,Z)"
         write(*,'(T2,"Nenergy = ",i3)'),fbm%nenergy
         write(*,'(T2,"Npitch  = ",i3)'),fbm%npitch
         write(*,'(T2,"Energy range = [",f5.2,",",f6.2,"]")'),fbm%emin,fbm%emax
         write(*,'(T2,"Pitch  range = [",f5.2,",",f5.2,"]")'),fbm%pmin,fbm%pmax
+        write(*,'(T2,"Ntotal = ",ES10.3)') fbm%n_tot
         write(*,*) ''
     endif
 
@@ -2304,7 +2350,7 @@ subroutine read_mc(fid, error)
     integer(HSIZE_T), dimension(1) :: dims
     integer(Int32) :: i,j,ii,ir,iz
     real(Float64) :: phi,phi_enter,phi_exit,delta_phi,r_ratio
-    real(Float64), dimension(3) :: uvw,ri,vi,e1_xyz,e2_xyz,C_xyz
+    real(Float64), dimension(3) :: uvw,ri,vi,e1_xyz,e2_xyz,C_xyz,dum
     integer(Int32), dimension(1) :: minpos
     real(Float64), dimension(:), allocatable :: weight
     real(Float64), dimension(:), allocatable :: r, z, vr, vt, vz
@@ -2342,6 +2388,11 @@ subroutine read_mc(fid, error)
     call h5ltread_dataset_double_f(fid, "/weight", weight, dims, error)
     call h5ltread_dataset_int_f(fid, "/class", orbit_class, dims, error)
 
+    if(any(orbit_class.gt.particles%nclass)) then
+        write(*,'(a)') 'READ_MC: Orbit class ID greater then the number of classes'
+        stop
+    endif
+
     if(inputs%dist_type.eq.2) then
         dist_type_name = "Guiding Center Monte Carlo"
         allocate(energy(npart))
@@ -2364,13 +2415,13 @@ subroutine read_mc(fid, error)
         if(inputs%verbose.ge.2) then
             WRITE(*,'(f7.2,"% completed",a,$)') cnt/real(npart)*100,char(13)
         endif
-        call in_plasma([r(i),0.d0,z(i)],inp,machine_coords=.True.)
+        uvw = [r(i), 0.d0, z(i)]
+        call in_plasma(uvw,inp,machine_coords=.True.)
         if(.not.inp) cycle particle_loop
         do ii=1,nrep
             j = int((i-1)*nrep + ii)
             if(inputs%dist_type.eq.2) then
                 !! Transform to full orbit
-                uvw = [r(i), 0.d0, z(i)]
                 call get_fields(fields,pos = uvw, machine_coords=.True.)
                 call gyro_correction(fields, uvw, energy(i), pitch(i), ri, vi)
                 particles%fast_ion(j)%r = sqrt(ri(1)**2 + ri(2)**2)
@@ -2398,13 +2449,15 @@ subroutine read_mc(fid, error)
 
             phi_enter = 0.0
             phi_exit = 0.0
-            call uvw_to_xyz([0.d0, 0.d0, particles%fast_ion(j)%z], C_xyz)
+            dum = [0.d0, 0.d0, particles%fast_ion(j)%z]
+            call uvw_to_xyz(dum, C_xyz)
             call circle_grid_intersect(C_xyz,e1_xyz,e2_xyz,particles%fast_ion(j)%r,phi_enter,phi_exit)
             delta_phi = phi_exit-phi_enter
             if(delta_phi.gt.0) then
                 particles%fast_ion(j)%cross_grid = .True.
             else
                 particles%fast_ion(j)%cross_grid = .False.
+                delta_phi = 2*pi
             endif
             particles%fast_ion(j)%phi_enter = phi_enter
             particles%fast_ion(j)%delta_phi = delta_phi
@@ -2468,7 +2521,7 @@ subroutine read_distribution
 
 end subroutine read_distribution
 
-subroutine read_cross(fid, grp, cross)
+subroutine read_atomic_cross(fid, grp, cross)
     !+ Reads in a cross section table from file
     !+ and puts it into a [[AtomicCrossSection]] type
     integer(HID_T), intent(in)              :: fid
@@ -2508,10 +2561,10 @@ subroutine read_cross(fid, grp, cross)
     enddo
     deallocate(dummy3)
 
-end subroutine read_cross
+end subroutine read_atomic_cross
 
-subroutine read_rates(fid, grp, b_amu, t_amu, rates)
-    !+ Reads in a reaction rates table from file
+subroutine read_atomic_rates(fid, grp, b_amu, t_amu, rates)
+    !+ Reads in a atomic reaction rates table from file
     !+ and puts it into a [[AtomicRates]] type
     integer(HID_T), intent(in)              :: fid
         !+ HDF5 file ID
@@ -2688,7 +2741,66 @@ subroutine read_rates(fid, grp, b_amu, t_amu, rates)
     rates%minlog_pop = log10(rmin)
     rates%log_pop = log10(rates%log_pop)
 
-end subroutine read_rates
+end subroutine read_atomic_rates
+
+subroutine read_nuclear_rates(fid, grp, rates)
+    !+ Reads in a nuclear reaction rates table from file
+    !+ and puts it into a [[NuclearRates]] type
+    integer(HID_T), intent(in)              :: fid
+        !+ HDF5 file ID
+    character(len=*), intent(in)            :: grp
+        !+ HDF5 group to read from
+    type(NuclearRates), intent(inout)       :: rates
+        !+ Atomic reaction rates
+
+    integer(HSIZE_T), dimension(1) :: dim1
+    integer(HSIZE_T), dimension(3) :: dim3
+    logical :: path_valid
+    integer :: i, j, error
+    real(Float64) :: emin, emax, tmin, tmax, rmin
+
+    call h5ltread_dataset_int_scalar_f(fid, grp//"/nbranch", rates%nbranch, error)
+    call h5ltread_dataset_int_scalar_f(fid, grp//"/nenergy", rates%nenergy, error)
+    call h5ltread_dataset_double_scalar_f(fid, grp//"/emin", emin, error)
+    call h5ltread_dataset_double_scalar_f(fid, grp//"/emax", emax, error)
+    call h5ltread_dataset_double_scalar_f(fid, grp//"/dlogE", rates%dlogE, error)
+    call h5ltread_dataset_int_scalar_f(fid, grp//"/ntemp", rates%ntemp, error)
+    call h5ltread_dataset_double_scalar_f(fid, grp//"/tmin", tmin, error)
+    call h5ltread_dataset_double_scalar_f(fid, grp//"/tmax", tmax, error)
+    call h5ltread_dataset_double_scalar_f(fid, grp//"/dlogT", rates%dlogT, error)
+    rates%logemin = log10(emin)
+    rates%logemax = log10(emax)
+    rates%logtmin = log10(tmin)
+    rates%logtmax = log10(tmax)
+
+    allocate(rates%log_rate(rates%nenergy, &
+                            rates%ntemp,   &
+                            rates%nbranch))
+
+    dim1 = [2]
+    call h5ltread_dataset_double_f(fid, grp//"/bt_amu", rates%bt_amu, dim1, error)
+
+    if(abs(inputs%ab-rates%bt_amu(1)).gt.0.2) then
+        write(*,'(a,f6.3,a,f6.3,a)') 'READ_NUCLEAR_RATES: Unexpected beam species mass. Expected ',&
+            rates%bt_amu(1),' amu got ', inputs%ab, ' amu'
+    endif
+
+    if(abs(inputs%ai-rates%bt_amu(2)).gt.0.2) then
+        write(*,'(a,f6.3,a,f6.3,a)') 'READ_NUCLEAR_RATES: Unexpected thermal species mass. Expected ',&
+            rates%bt_amu(2),' amu got ', inputs%ai, ' amu'
+    endif
+
+    dim3 = [rates%nenergy, rates%ntemp, rates%nbranch]
+    call h5ltread_dataset_double_f(fid, grp//"/fusion", rates%log_rate, dim3, error)
+
+    rmin = minval(rates%log_rate, rates%log_rate.gt.0.d0)
+    where (rates%log_rate.le.0.d0)
+        rates%log_rate = 0.9*rmin
+    end where
+    rates%minlog_rate = log10(rmin)
+    rates%log_rate = log10(rates%log_rate)
+
+end subroutine read_nuclear_rates
 
 subroutine read_tables
     !+ Reads in atomic tables from file and stores them in [[libfida:tables]]
@@ -2713,16 +2825,16 @@ subroutine read_tables
     call h5fopen_f(inputs%tables_file, H5F_ACC_RDONLY_F, fid, error)
 
     !!Read Hydrogen-Hydrogen CX Cross Sections
-    call read_cross(fid,"/cross/H_H",tables%H_H_cx)
+    call read_atomic_cross(fid,"/cross/H_H",tables%H_H_cx)
 
     !!Read Hydrogen-Hydrogen Rates
     b_amu = [inputs%ab, inputs%ai]
-    call read_rates(fid,"/rates/H_H",b_amu, inputs%ai, tables%H_H)
+    call read_atomic_rates(fid,"/rates/H_H",b_amu, inputs%ai, tables%H_H)
     inputs%ab = tables%H_H%ab(1)
     inputs%ai = tables%H_H%ab(2)
 
     !!Read Hydrogen-Electron Rates
-    call read_rates(fid,"/rates/H_e",b_amu, e_amu, tables%H_e)
+    call read_atomic_rates(fid,"/rates/H_e",b_amu, e_amu, tables%H_e)
 
     !!Read Hydrogen-Impurity rates
     impname = ''
@@ -2738,7 +2850,7 @@ subroutine read_tables
             imp_amu = 2.d0*inputs%impurity_charge
     end select
 
-    call read_rates(fid,"/rates/H_"//trim(adjustl(impname)), b_amu, imp_amu, tables%H_Aq)
+    call read_atomic_rates(fid,"/rates/H_"//trim(adjustl(impname)), b_amu, imp_amu, tables%H_Aq)
 
     !!Read Einstein coefficients
     call h5ltread_dataset_int_scalar_f(fid,"/rates/spontaneous/n_max", n_max, error)
@@ -2748,6 +2860,9 @@ subroutine read_tables
     call h5ltread_dataset_double_f(fid,"/rates/spontaneous/einstein",dummy2, dim2, error)
     tables%einstein(:,:) = transpose(dummy2(1:nlevs,1:nlevs))
     deallocate(dummy2)
+
+    !!Read nuclear Deuterium-Deuterium rates
+    call read_nuclear_rates(fid, "/rates/D_D", tables%D_D)
 
     !!Close file
     call h5fclose_f(fid, error)
@@ -3127,8 +3242,8 @@ subroutine write_npa
 
     !Write variables
     d(1) = 1
-    dim2 = [fbm%nenergy, npa%nchan]
-    call h5ltmake_dataset_int_f(fid,"/nenergy", 0, d, [fbm%nenergy], error)
+    dim2 = [npa%nenergy, npa%nchan]
+    call h5ltmake_dataset_int_f(fid,"/nenergy", 0, d, [npa%nenergy], error)
     call h5ltmake_dataset_int_f(fid,"/nchan", 0, d, [npa%nchan], error)
     call h5ltmake_compressed_dataset_double_f(fid,"/energy",1,dim2(1:1),&
          npa%energy, error)
@@ -3351,6 +3466,54 @@ subroutine write_spectra
     endif
 
 end subroutine write_spectra
+
+subroutine write_neutrons
+    !+ Writes [[libfida:neutron]] to a HDF5 file
+    integer(HID_T) :: fid
+    integer(HSIZE_T), dimension(1) :: dim1
+    integer :: error
+
+    character(charlim) :: filename
+
+    !! write to file
+    filename=trim(adjustl(inputs%result_dir))//"/"//trim(adjustl(inputs%runid))//"_neutrons.h5"
+
+    !Open HDF5 interface
+    call h5open_f(error)
+
+    !Create file overwriting any existing file
+    call h5fcreate_f(filename, H5F_ACC_TRUNC_F, fid, error)
+
+    !Write variables
+    if(particles%nclass.gt.1) then
+        dim1(1) = particles%nclass
+        call h5ltmake_compressed_dataset_double_f(fid, "/rate", 1, dim1, neutron%rate, error)
+        call h5ltset_attribute_string_f(fid,"/rate","description", &
+             "Neutron rate: rate(orbit_class)", error)
+    else
+        dim1(1) = 1
+        call h5ltmake_dataset_double_f(fid, "/rate", 0, dim1, neutron%rate, error)
+        call h5ltset_attribute_string_f(fid,"/rate","description", &
+             "Neutron rate", error)
+    endif
+
+    call h5ltset_attribute_string_f(fid,"/rate","units","neutrons/s",error )
+
+    call h5ltset_attribute_string_f(fid, "/", "version", version, error)
+    call h5ltset_attribute_string_f(fid,"/","description",&
+         "Neutron rate calculated by FIDASIM", error)
+
+    !Close file
+    call h5fclose_f(fid, error)
+
+    !Close HDF5 interface
+    call h5close_f(error)
+
+    if(inputs%verbose.ge.1) then
+        write(*,'(T4,a,a)') 'Neutrons written to: ', trim(filename)
+    endif
+
+end subroutine write_neutrons
 
 subroutine write_fida_weights
     !+ Writes [[libfida:fweight]] to a HDF5 file
@@ -4959,7 +5122,7 @@ subroutine store_npa(det, ri, rf, vn, flux)
 
     type(LocalEMFields) :: fields
     real(Float64), dimension(3) :: uvw_ri, uvw_rf,vn_norm
-    real(Float64) :: energy, pitch
+    real(Float64) :: energy, pitch, dE
     integer(Int32), dimension(1) :: ienergy
     type(NPAParticle), dimension(:), allocatable :: parts
 
@@ -4969,6 +5132,7 @@ subroutine store_npa(det, ri, rf, vn, flux)
 
     ! Calculate energy
     energy = inputs%ab*v2_to_E_per_amu*dot_product(vn,vn)
+    dE = npa%energy(2)-npa%energy(1)
 
     ! Calculate pitch if distribution actually uses pitch
     if(inputs%dist_type.le.2) then
@@ -5001,7 +5165,7 @@ subroutine store_npa(det, ri, rf, vn, flux)
     npa%part(npa%npart)%pitch = pitch
     npa%part(npa%npart)%weight = flux
     ienergy = minloc(abs(npa%energy - energy))
-    npa%flux(ienergy(1),det) = npa%flux(ienergy(1),det) + flux/fbm%dE
+    npa%flux(ienergy(1),det) = npa%flux(ienergy(1),det) + flux/dE
     !$OMP END CRITICAL(store_npa_1)
 
 end subroutine store_npa
@@ -5038,7 +5202,7 @@ subroutine neut_rates(denn, vi, vn, rates)
     ebi = c%i
     if(err.eq.1) then
         write(*,'(a)') "NEUT_RATES: Eb out of range of H_H_cx table. Using nearest energy value."
-        write(*,'("eb = ",f5.3," [keV]")') eb
+        write(*,'("eb = ",f6.3," [keV]")') eb
         if(ebi.lt.1) then
             ebi=1
             c%b1=1.0 ; c%b2=0.0
@@ -5060,6 +5224,61 @@ subroutine neut_rates(denn, vi, vn, rates)
     rates=matmul(neut,denn)*vrel
 
 end subroutine neut_rates
+
+subroutine get_neutron_rate(plasma, eb, rate)
+    !+ Gets neutron rate for a beam with energy `eb` interacting with a target plasma
+    type(LocalProfiles), intent(in) :: plasma
+        !+ Plasma Paramters
+    real(Float64), intent(in)       :: eb
+        !+ Beam energy [keV]
+    real(Float64), intent(out)      :: rate
+        !+ Neutron reaction rate [1/s]
+
+    integer :: err_status, neb, nt, ebi, tii
+    real(Float64) :: dlogE, dlogT, logEmin, logTmin
+    real(Float64) :: logeb, logti, lograte, denp
+    type(InterpolCoeffs2D) :: c
+    real(Float64) :: b11, b12, b21, b22
+
+    logeb = log10(eb)
+    logti = log10(plasma%ti)
+    denp = plasma%denp
+
+    !!D_D
+    err_status = 1
+    logEmin = tables%D_D%logemin
+    logTmin = tables%D_D%logtmin
+    dlogE = tables%D_D%dlogE
+    dlogT = tables%D_D%dlogT
+    neb = tables%D_D%nenergy
+    nt = tables%D_D%ntemp
+    call interpol_coeff(logEmin, dlogE, neb, logTmin, dlogT, nt, &
+                        logeb, logti, c, err_status)
+    ebi = c%i
+    tii = c%j
+    b11 = c%b11
+    b12 = c%b12
+    b21 = c%b21
+    b22 = c%b22
+    if(err_status.eq.1) then
+        write(*,'(a)') "GET_NEUTRON_RATE: Eb or Ti out of range of D_D table. Setting D_D rates to zero"
+        write(*,'("eb = ",f6.3," [keV]")') eb
+        write(*,'("ti = ",f6.3," [keV]")') plasma%ti
+        denp = 0.d0
+    endif
+
+    lograte = (b11*tables%D_D%log_rate(ebi,tii,2)   + &
+               b12*tables%D_D%log_rate(ebi,tii+1,2) + &
+               b21*tables%D_D%log_rate(ebi+1,tii,2) + &
+               b22*tables%D_D%log_rate(ebi+1,tii+1,2))
+
+    if (lograte.lt.tables%D_D%minlog_rate) then
+        rate = 0.d0
+    else
+        rate = denp * 10.d0**lograte
+    endif
+
+end subroutine get_neutron_rate
 
 subroutine get_beam_cx_prob(ind, pos, v_ion, types, prob)
     !+ Get probability of a thermal ion charge exchanging with `types` neutrals
@@ -5536,6 +5755,27 @@ subroutine store_fida_photons(pos, vi, photons, orbit_class)
 
 end subroutine store_fida_photons
 
+subroutine store_neutrons(rate, orbit_class)
+    !+ Store neutron rate in [[libfida:neutron]]
+    real(Float64), intent(in)     :: rate
+        !+ Neutron rate [neutrons/sec]
+    integer, intent(in), optional :: orbit_class
+        !+ Orbit class ID
+
+    integer :: iclass
+
+    if(present(orbit_class)) then
+        iclass = orbit_class
+    else
+        iclass = 1
+    endif
+
+    !$OMP CRITICAL(neutron_rate)
+    neutron%rate(iclass)= neutron%rate(iclass) + rate
+    !$OMP END CRITICAL(neutron_rate)
+
+end subroutine store_neutrons
+
 subroutine store_fw_photons_at_chan(ichan,eind,pind,vp,vi,fields,dlength,sigma_pi,denf,photons)
     !+ Store FIDA weight photons in [[libfida:fweight]] for a specific channel
     integer, intent(in)                     :: ichan
@@ -5686,7 +5926,7 @@ subroutine pitch_to_vec(pitch, gyroangle, fields, vi_norm)
 
     real(Float64) :: sinus
 
-    sinus = sqrt(1.d0-pitch**2)
+    sinus = sqrt(max(1.d0-pitch**2,0.d0))
     vi_norm = (sinus*cos(gyroangle)*fields%a_norm + &
                pitch*fields%b_norm + &
                sinus*sin(gyroangle)*fields%c_norm)
@@ -6623,12 +6863,12 @@ end subroutine npa_f
 
 subroutine npa_mc
     !+ Calculate NPA flux using a Monte Carlo fast-ion distribution
-    integer :: iion
+    integer :: iion,iloop
     type(FastIon) :: fast_ion
     real(Float64) :: phi
     real(Float64), dimension(3) :: ri, rf      !! positions
     real(Float64), dimension(3) :: vi          !! velocity of fast ions
-    integer :: det !! detector
+    integer :: det,j !! detector
     real(Float64), dimension(nlevs) :: prob    !! Prob. for CX
     real(Float64), dimension(nlevs) :: states  ! Density of n-states
     real(Float64) :: flux
@@ -6641,11 +6881,15 @@ subroutine npa_mc
 
     maxcnt=particles%nparticle
     inv_maxcnt = 100.d0/maxcnt
+    if(inputs%verbose.ge.1) then
+        write(*,'(T6,"# of markers: ",i9)') particles%nparticle
+    endif
 
     cnt=0.0
-    !$OMP PARALLEL DO schedule(guided) private(iion,ind,fast_ion,vi,ri,rf,phi,s,c, &
+    !$OMP PARALLEL DO schedule(guided) private(iion,iloop,ind,fast_ion,vi,ri,rf,phi,s,c, &
     !$OMP& randomu,uvw,uvw_vi,prob,states,flux,det)
     loop_over_fast_ions: do iion=1,particles%nparticle
+        cnt=cnt+1
         fast_ion = particles%fast_ion(iion)
         if(fast_ion%vabs.eq.0)cycle loop_over_fast_ions
         if(fast_ion%cross_grid) then
@@ -6675,7 +6919,7 @@ subroutine npa_mc
 
             !! Calculate CX probability with beam and halo neutrals
             call get_beam_cx_prob(ind,ri,vi,neut_types,prob)
-            if(sum(prob).le.0.)cycle loop_over_fast_ions
+            if(sum(prob).le.0.) cycle loop_over_fast_ions
 
             !! Attenuate states as the particle moves though plasma
             states=prob*fast_ion%weight
@@ -6685,7 +6929,6 @@ subroutine npa_mc
             flux = sum(states)*beam_grid%dv
             call store_npa(det,ri,rf,vi,flux)
         endif
-        cnt=cnt+1
         if (inputs%verbose.ge.2)then
           WRITE(*,'(f7.2,"% completed",a,$)') cnt*inv_maxcnt,char(13)
         endif
@@ -6693,6 +6936,147 @@ subroutine npa_mc
     !$OMP END PARALLEL DO
 
 end subroutine npa_mc
+
+subroutine neutron_f
+    !+ Calculate neutron emission rate using a fast-ion distribution function F(E,p,r,z)
+    integer :: ir, iz, ie, ip, iphi, nphi
+    type(LocalProfiles) :: plasma
+    type(LocalEMFields) :: fields
+    real(Float64) :: eb,pitch,r,z
+    real(Float64) :: erel, rate
+    real(Float64), dimension(3) :: rg, ri
+    real(Float64), dimension(3) :: vi
+    real(Float64), dimension(3) :: uvw, uvw_vi
+    real(Float64)  :: vnet_square, factor
+    real(Float64)  :: maxcnt, inv_maxcnt, cnt
+
+    nphi = 20
+    maxcnt=fbm%nr*fbm%nz
+    inv_maxcnt = 100.d0/maxcnt
+    cnt=0.0
+    !$OMP PARALLEL DO schedule(guided) private(fields,vi,ri,rg,pitch,eb,&
+    !$OMP& ir,iz,ie,ip,iphi,plasma,factor,uvw,uvw_vi,vnet_square,rate,erel)
+    z_loop: do iz = 1, fbm%nz
+        r_loop: do ir=1, fbm%nr
+            cnt = cnt+1
+            !! Calculate position
+            uvw(1) = fbm%r(ir)
+            uvw(2) = 0.d0
+            uvw(3) = fbm%z(iz)
+            call uvw_to_xyz(uvw, rg)
+
+            !! Get fields
+            call get_fields(fields,pos=rg)
+            if(.not.fields%in_plasma) cycle r_loop
+
+            factor = 2*pi*fbm%r(ir)*fbm%dE*fbm%dp*fbm%dr*fbm%dz
+            !! Loop over energy/pitch/phi
+            pitch_loop: do ip = 1, fbm%npitch
+                pitch = fbm%pitch(ip)
+                energy_loop: do ie =1, fbm%nenergy
+                    eb = fbm%energy(ie)
+                    gyro_loop: do iphi=1, nphi 
+                        call gyro_correction(fields,rg,eb,pitch,ri,vi)
+
+                        !! Get plasma parameters at particle position
+                        call get_plasma(plasma,pos=ri)
+                        if(.not.plasma%in_plasma) cycle gyro_loop
+
+                        !! Calculate effective beam energy
+                        vnet_square=dot_product(vi-plasma%vrot,vi-plasma%vrot)  ![cm/s]
+                        erel = v2_to_E_per_amu*inputs%ab*vnet_square ![kev]
+
+                        !! Get neutron production rate
+                        call get_neutron_rate(plasma, erel, rate)
+                        rate = rate*fbm%f(ie,ip,ir,iz)*factor
+
+                        !! Store neutrons
+                        call store_neutrons(rate/nphi)
+                    enddo gyro_loop
+                enddo energy_loop
+            enddo pitch_loop
+            if (inputs%verbose.ge.2)then
+              WRITE(*,'(f7.2,"% completed",a,$)') cnt*inv_maxcnt,char(13)
+            endif
+        enddo r_loop
+    enddo z_loop
+    !$OMP END PARALLEL DO
+
+    if(inputs%verbose.ge.1) then
+        write(*,'(T4,A,ES14.5," [neutrons/s]")'),'Rate:   ',sum(neutron%rate)
+        write(*,'(30X,a)') ''
+    endif
+
+    call write_neutrons()
+
+end subroutine neutron_f
+
+subroutine neutron_mc
+    !+ Calculate neutron flux using a Monte Carlo Fast-ion distribution
+    integer :: iion
+    type(FastIon) :: fast_ion
+    type(LocalProfiles) :: plasma
+    real(Float64) :: eb, rate
+    real(Float64), dimension(3) :: ri      !! start position
+    real(Float64), dimension(3) :: vi      !! velocity of fast ions
+    real(Float64), dimension(3) :: uvw, uvw_vi
+    real(Float64)  :: vnet_square
+    real(Float64)  :: maxcnt, inv_maxcnt, cnt
+    real(Float64), dimension(1) :: randomu
+
+    maxcnt=particles%nparticle
+    inv_maxcnt = 100.d0/maxcnt
+    if(inputs%verbose.ge.1) then
+        write(*,'(T6,"# of markers: ",i9)') particles%nparticle
+    endif
+
+    cnt=0.0
+    rate=0.0
+    !$OMP PARALLEL DO schedule(guided) private(iion,fast_ion,vi,ri, &
+    !$OMP& plasma,randomu,uvw,uvw_vi,vnet_square,rate,eb)
+    loop_over_fast_ions: do iion=1,particles%nparticle
+        cnt=cnt+1
+        fast_ion = particles%fast_ion(iion)
+        if(fast_ion%vabs.eq.0) cycle loop_over_fast_ions
+
+        !! Calculate position
+        uvw(1) = fast_ion%r
+        uvw(2) = 0.0
+        uvw(3) = fast_ion%z
+        call uvw_to_xyz(uvw, ri)
+
+        !! Get plasma parameters
+        call get_plasma(plasma,pos=ri)
+
+        !! Calculate effective beam energy
+        uvw_vi(1) = fast_ion%vr
+        uvw_vi(2) = fast_ion%vt
+        uvw_vi(3) = fast_ion%vz
+        vi = matmul(beam_grid%inv_basis,uvw_vi)
+        vnet_square=dot_product(vi-plasma%vrot,vi-plasma%vrot)  ![cm/s]
+        eb = v2_to_E_per_amu*inputs%ab*vnet_square ![kev]
+
+        !! Get neutron production rate
+        call get_neutron_rate(plasma, eb, rate)
+        rate = rate*fast_ion%weight*(2*pi/fast_ion%delta_phi)*beam_grid%dv
+
+        !! Store neutrons
+        call store_neutrons(rate, fast_ion%class)
+
+        if (inputs%verbose.ge.2)then
+          WRITE(*,'(f7.2,"% completed",a,$)') cnt*inv_maxcnt,char(13)
+        endif
+    enddo loop_over_fast_ions
+    !$OMP END PARALLEL DO
+
+    if(inputs%verbose.ge.1) then
+        write(*,'(T4,A,ES14.5," [neutrons/s]")'),'Rate:   ',sum(neutron%rate)
+        write(*,'(30X,a)') ''
+    endif
+
+    call write_neutrons()
+
+end subroutine neutron_mc
 
 subroutine fida_weights_mc
     !+ Calculates FIDA weights
@@ -7066,6 +7450,7 @@ end subroutine fida_weights_los
 subroutine npa_weights
     !+ Calculates NPA weights
     type(LocalEMFields) :: fields
+    type(NPAProbability) :: phit
     real(Float64) :: pitch
     real(Float64) :: pcxa
     integer(Int32) :: det
@@ -7139,21 +7524,19 @@ subroutine npa_weights
         endif
 
         ccnt=0.d0
-        !$OMP PARALLEL DO schedule(guided) collapse(3) private(ii,jj,kk,fields, &
+        !$OMP PARALLEL DO schedule(guided) collapse(3) private(ii,jj,kk,fields,phit,&
         !$OMP& ic,det,pos,dpos,r_gyro,pitch,ipitch,vabs,vi,pcx,pcxa,states,states_i,vi_norm,fbm_denf)
         loop_along_z: do kk=1,beam_grid%nz
             loop_along_y: do jj=1,beam_grid%ny
                 loop_along_x: do ii=1,beam_grid%nx
-                    if(npa_chords%phit(ii,jj,kk,ichan)%p.gt.0.d0) then
+                    phit = npa_chords%phit(ii,jj,kk,ichan)
+                    if(phit%p.gt.0.d0) then
                         pos = [beam_grid%xc(ii), beam_grid%yc(jj), beam_grid%zc(kk)]
                         call get_fields(fields,pos=pos)
                         if(.not.fields%in_plasma) cycle loop_along_x
 
-                        !!Determine velocity vector
-                        dpos = npa_chords%phit(ii,jj,kk,ichan)%eff_rd
-                        vi_norm = (dpos - pos)/norm2(dpos - pos)
-
                         !!Check if it hits a detector just to make sure
+                        vi_norm = phit%dir
                         call hit_npa_detector(pos,vi_norm,det)
                         if (det.ne.ichan) then
                             write(*,'(a)') 'NPA_WEIGHTS: Missed detector'
@@ -7161,7 +7544,7 @@ subroutine npa_weights
                         endif
 
                         !! Determine the angle between the B-field and the Line of Sight
-                        pitch = dot_product(fields%b_norm,vi_norm)
+                        pitch = phit%pitch
                         ipitch=minloc(abs(ptcharr - pitch))
                         loop_over_energy: do ic = 1, inputs%ne_wght !! energy loop
                             vabs = sqrt(ebarr(ic)/(v2_to_E_per_amu*inputs%ab))
@@ -7190,13 +7573,13 @@ subroutine npa_weights
                             nweight%attenuation(ic,ii,jj,kk,ichan) = pcxa
                             nweight%cx(ic,ii,jj,kk,ichan) = sum(pcx)
                             nweight%weight(ic,ipitch(1),ichan) = nweight%weight(ic,ipitch(1),ichan) + &
-                                      2*sum(pcx)*pcxa*npa_chords%phit(ii,jj,kk,ichan)%p*beam_grid%dv/dP
+                                      2*sum(pcx)*pcxa*phit%p*beam_grid%dv/dP
 
                             nweight%flux(ic,ichan) = nweight%flux(ic,ichan) + &
-                                      2*beam_grid%dv*fbm_denf*sum(pcx)*pcxa*npa_chords%phit(ii,jj,kk,ichan)%p
+                                      2*beam_grid%dv*fbm_denf*sum(pcx)*pcxa*phit%p
                                       !Factor of 2 above is to convert fbm to ions/(cm^3 dE (domega/4pi))
                             nweight%emissivity(ii,jj,kk,ichan)=nweight%emissivity(ii,jj,kk,ichan)+ &
-                                      2*fbm_denf*sum(pcx)*pcxa*npa_chords%phit(ii,jj,kk,ichan)%p*dE
+                                      2*fbm_denf*sum(pcx)*pcxa*phit%p*dE
                             !$OMP END CRITICAL(npa_wght)
                         enddo loop_over_energy
                     endif
@@ -7342,10 +7725,23 @@ program fidasim
     if(inputs%calc_npa.ge.1)then
         npa%nchan = npa_chords%nchan
         allocate(npa%part(npa%nmax))
-        allocate(npa%energy(fbm%nenergy))
-        allocate(npa%flux(fbm%nenergy,npa%nchan))
-        npa%energy = fbm%energy
+        if(inputs%dist_type.eq.1) then
+            npa%nenergy = fbm%nenergy
+            allocate(npa%energy(npa%nenergy))
+            npa%energy = fbm%energy
+        else
+            allocate(npa%energy(npa%nenergy))
+            do i=1,npa%nenergy
+                npa%energy(i)=real(i-0.5)
+            enddo
+        endif
+        allocate(npa%flux(npa%nenergy,npa%nchan))
         npa%flux = 0.0
+    endif
+
+    if(inputs%calc_neutron.ge.1)then
+        allocate(neutron%rate(particles%nclass))
+        neutron%rate = 0.d0
     endif
 
     !! -----------------------------------------------------------------------
@@ -7442,6 +7838,23 @@ program fidasim
 
     if(inputs%calc_npa.ge.1) then
         call write_npa()
+        write(*,'(30X,a)') ''
+    endif
+
+    !! -------------------------------------------------------------------
+    !! ------------------- Calculation of neutron flux -------------------
+    !! -------------------------------------------------------------------
+    if(inputs%calc_neutron.ge.1) then
+        call date_and_time (values=time_arr)
+        if(inputs%verbose.ge.1) then
+            write(*,'(A,I2,":",I2.2,":",I2.2)') 'neutron rate:    ',  &
+                  time_arr(5),time_arr(6),time_arr(7)
+        endif
+        if(inputs%dist_type.eq.1) then
+            call neutron_f()
+        else
+            call neutron_mc()
+        endif
         write(*,'(30X,a)') ''
     endif
 

--- a/tables/atomic_tables.f90
+++ b/tables/atomic_tables.f90
@@ -6,16 +6,17 @@ module atomic_tables
 !+
 !+1. [W.L. Wiese, M.W. Smith, and B.M. Glennon. *Atomic Transition Probabilities. Volume 1. Hydrogen through Neon*.
 !+National Bureau of Standards Washington DC Institute for Basic Standards, 1966.](http://www.dtic.mil/dtic/tr/fulltext/u2/634145.pdf)
-!+2. [R.K. Janev, D. Reiter, and  U. Samm. *Collision processes in low-temperature hydrogen plasmas*. 
+!+2. [R.K. Janev, D. Reiter, and  U. Samm. *Collision processes in low-temperature hydrogen plasmas*.
 !+Forschungszentrum Jülich, Zentralbibliothek, 2003.](http://www.eirene.de/report_4105.pdf)
-!+3. [M. O'Mullane. *Review of proton impact driven ionisation from the excited levels in neutral hydrogen beams*. 
+!+3. [M. O'Mullane. *Review of proton impact driven ionisation from the excited levels in neutral hydrogen beams*.
 !+ADAS note, 2009.](http://www.adas.ac.uk/notes/adas_c09-01.pdf)
 !+4. [ADAS: Atomic Data and Analysis Structure](http://www.adas.ac.uk/)
-!+5. [R.K. Janev and J.J. Smith. *Cross sections for collision processes of hydrogen atoms 
+!+5. [R.K. Janev and J.J. Smith. *Cross sections for collision processes of hydrogen atoms
 !+with electrons, protons and multiply charged ions.* Atomic and Plasma-Material Interaction Data for Fusion:
-!+Volume 4, 1993.](http://www-pub.iaea.org/books/IAEABooks/1839/Atomic-and-Plasma-Material-Interaction-Data-for-Fusion) 
-!+6. [Reinhold, C. O., R. E. Olson, and W. Fritsch. *Excitation of atomic hydrogen by fully stripped ions.* 
+!+Volume 4, 1993.](http://www-pub.iaea.org/books/IAEABooks/1839/Atomic-and-Plasma-Material-Interaction-Data-for-Fusion)
+!+6. [Reinhold, C. O., R. E. Olson, and W. Fritsch. *Excitation of atomic hydrogen by fully stripped ions.*
 !+Physical Review A 41.9 1990.](http://journals.aps.org/pra/abstract/10.1103/PhysRevA.41.4837)
+!+7. [NRL Plasma Formulary (2016)](https://www.nrl.navy.mil/ppd/content/nrl-plasma-formulary)
 use H5LT
 use HDF5
 use hdf5_extra
@@ -23,8 +24,9 @@ use hdf5_extra
 IMPLICIT NONE
 
 interface bt_maxwellian
-    !+Calculates the reaction rate coefficients given beam energy `eb` and target temperature `T` 
+    !+Calculates the reaction rate coefficients given beam energy `eb` and target temperature `T`
     !+where the velocity distribution of the target is a Maxwellian
+    module procedure bt_maxwellian_eb
     module procedure bt_maxwellian_n, bt_maxwellian_n_m
     module procedure bt_maxwellian_q_n, bt_maxwellian_q_n_m
 end interface
@@ -33,18 +35,22 @@ integer, parameter, private   :: Int32   = 4
     !+ Defines a 32 bit integer
 integer, parameter, private   :: Int64   = 8
     !+ Defines a 64 bit integer
-integer, parameter, private   :: Float32 = 4 
+integer, parameter, private   :: Float32 = 4
     !+ Defines a 32 bit floating point real
 integer, parameter, private   :: Float64 = 8
-    !+ Defines a 64 bit floating point real 
+    !+ Defines a 64 bit floating point real
 
 real(Float64), parameter :: PI = 3.14159265d0
 real(Float64), parameter :: e_amu = 5.485799093287202d-4
     !+ Atomic mass of an electron [amu]
 real(Float64), parameter :: H1_amu = 1.00782504d0
-    !+ Atomic mass of Hydrogen-1 (protium) [amu] 
+    !+ Atomic mass of Hydrogen-1 (protium) [amu]
 real(Float64), parameter :: H2_amu = 2.0141017778d0
     !+ Atomic mass of Hydrogen-2 (deuterium) [amu]
+real(Float64), parameter :: H3_amu = 3.0160492d0
+    !+ Atomic mass of Hydrogen-3 (tritium) [amu]
+real(Float64), parameter :: He3_amu = 3.0160293d0
+    !+ Atomic mass of Helium-3 [amu]
 real(Float64), parameter :: B_amu = 10.81d0
     !+ Atomic mass of Boron [amu]
 real(Float64), parameter :: C_amu = 12.011d0
@@ -56,7 +62,7 @@ integer, parameter :: C_q = 6
     !+ Proton number of Carbon
 
 real(Float64), dimension(15,15), parameter :: EINSTEIN = reshape([ &                                                  !(n,m)
-0.d0,4.699d8,5.575d7,1.278d7,4.125d6,1.644d6,7.568d5,3.869d5,2.143d5,1.263d5,7.834d4,5.066d4,3.393d4,2.341d4,1.657d4,&!(:,1) 
+0.d0,4.699d8,5.575d7,1.278d7,4.125d6,1.644d6,7.568d5,3.869d5,2.143d5,1.263d5,7.834d4,5.066d4,3.393d4,2.341d4,1.657d4,&!(:,1)
 0.d0,0.d0   ,4.410d7,8.419d6,2.530d6,9.732d5,4.389d5,2.215d5,1.216d5,7.122d4,4.397d4,2.834d4,1.893d4,1.303d4,9.210d3,&!(:,2)
 0.d0,0.d0   ,0.d0   ,8.986d6,2.201d6,7.783d5,3.358d5,1.651d5,8.905d4,5.156d4,3.156d4,2.021d4,1.343d4,9.211d3,6.490d3,&!(:,3)
 0.d0,0.d0   ,0.d0   ,0.d0   ,2.699d6,7.711d5,3.041d5,1.424d5,7.459d4,4.235d4,2.556d4,1.620d4,1.069d4,7.288d3,5.110d3,&!(:,4)
@@ -76,7 +82,7 @@ real(Float64), dimension(15,15), parameter :: EINSTEIN = reshape([ &            
     !+
     !+References:
     !+
-    !+* H - Table A in Ref. 1 [[atomic_tables(module)]] 
+    !+* H - Table A in Ref. 1 [[atomic_tables(module)]]
 
 contains
 
@@ -96,12 +102,12 @@ function p_cx_1_janev(Erel) result(sigma)
         !+ Fitting Parameters from Table 9 in Ref. 2
     real(Float64), parameter :: n = 1.d0
     real(Float64) :: Ehat
-  
+
     Ehat = Erel * n**2.0
-  
+
     sigma = (1.d-16*a(1)*(n**4))*log(a(2)/Ehat + a(3)) / &
-            (1.d0+a(4)*Ehat + a(5)*Ehat**(3.5) + a(6)*Ehat**(5.4)) 
-  
+            (1.d0+a(4)*Ehat + a(5)*Ehat**(3.5) + a(6)*Ehat**(5.4))
+
 end function p_cx_1_janev
 
 function p_cx_2_janev(Erel) result(sigma)
@@ -120,12 +126,12 @@ function p_cx_2_janev(Erel) result(sigma)
         !+ Fitting Parameters from Table 9 in Ref. 2
     real(Float64), parameter :: n = 2.d0
     real(Float64) :: Ehat
-  
+
     Ehat = Erel * n**2.0
-  
+
     sigma = (1.d-16*a(1)*(n**4))*log(a(2)/Ehat + a(3)) / &
-            (1.d0+a(4)*Ehat + a(5)*Ehat**(3.5) + a(6)*Ehat**(5.4)) 
-  
+            (1.d0+a(4)*Ehat + a(5)*Ehat**(3.5) + a(6)*Ehat**(5.4))
+
 end function p_cx_2_janev
 
 function p_cx_3_janev(Erel) result(sigma)
@@ -138,22 +144,22 @@ function p_cx_3_janev(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(6), parameter :: a = [3.7271d-1, 2.7645d6,  1.4857d3, &
                                                    1.5720d-3, 3.0842d-6, 1.1832d-10 ]
         !+ Fitting Parameters from Table 9 in Ref. 2
-  
-   
+
+
     real(Float64), parameter :: n = 3.d0
     real(Float64) :: Ehat
-  
+
     Ehat = Erel * n**2.0
-  
+
     sigma = (1.d-16*a(1)*(n**4))*log(a(2)/Ehat + a(3)) / &
-            (1.d0+a(4)*Ehat + a(5)*Ehat**(3.5) + a(6)*Ehat**(5.4)) 
-  
+            (1.d0+a(4)*Ehat + a(5)*Ehat**(3.5) + a(6)*Ehat**(5.4))
+
 end function p_cx_3_janev
-  
+
 function p_cx_n_janev(Erel, n) result(sigma)
     !+Calculates cross section for proton-Hydrogen charge exchange interactions from the \(n \geq 4\) state at energy `Erel`
     !+
@@ -167,13 +173,13 @@ function p_cx_n_janev(Erel, n) result(sigma)
     integer, intent(in)       :: n
         !+ Initial atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(6), parameter :: a = [2.1336d-1, 1.0000d10, 1.3426d6, &
                                                    1.8184d-3, 3.0842d-6, 1.1832d-10 ]
         !+ Fitting Parameters from Table 9 in Ref. 2
-   
+
     real(Float64) :: Ehat
- 
+
     if(n.lt.4) then
         write(*,'(a)') "P_CX_N_JANEV: n cannot be less than 4"
         stop
@@ -181,10 +187,10 @@ function p_cx_n_janev(Erel, n) result(sigma)
 
     Ehat = Erel * n**2.0
     sigma = (1.d-16*a(1)*(n**4))*log(a(2)/Ehat + a(3)) / &
-            (1.d0+a(4)*Ehat + a(5)*Ehat**(3.5) + a(6)*Ehat**(5.4)) 
- 
+            (1.d0+a(4)*Ehat + a(5)*Ehat**(3.5) + a(6)*Ehat**(5.4))
+
 end function p_cx_n_janev
-  
+
 function p_cx_janev(Erel,n) result(sigma)
     !+Calculates total cross section for proton-Hydrogen charge exchange interactions from the `n` state at energy `Erel`
     !+
@@ -197,29 +203,29 @@ function p_cx_janev(Erel,n) result(sigma)
     integer, intent(in)       :: n
         !+ Initial atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
 
     integer :: i
-  
+
     i = min(n,4)
-  
+
     select case (i)
-        case (0) 
+        case (0)
             stop
         case (1)
             sigma = p_cx_1_janev(Erel)
         case (2)
             sigma = p_cx_2_janev(Erel)
-        case (3) 
+        case (3)
             sigma = p_cx_3_janev(Erel)
-        case DEFAULT 
+        case DEFAULT
             sigma = p_cx_n_janev(Erel, n)
     end select
-  
+
 end function p_cx_janev
-  
+
 function p_cx_1_1_adas(Erel) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=1\) state to the \(m=1\) state at energy `Erel`
     !+
     !+###Equation
@@ -229,14 +235,14 @@ function p_cx_1_1_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(7), parameter :: a = [-3.496092687d2, 4.724931484d2, &
                                                    -2.720493064d2, 8.158564625d1, &
                                                    -1.339790721d1, 1.138706949d0, &
                                                    -3.914774156d-2 ]
     real(Float64) :: e, ee, fac, l, p
-  
+
     e = Erel*1.d3
     if(e.ge.1.d3) then
         ee = max(e,1.0)
@@ -245,18 +251,18 @@ function p_cx_1_1_adas(Erel) result(sigma)
         ee = 1.0d3
         fac = Erel**(-0.2)
     endif
-  
+
     l = log10(ee)
-  
+
     p = a(1) + a(2)*l + a(3)*l**2.0 + a(4)*l**3.0 + &
         a(5)*l**4.0   + a(6)*l**5.0 + a(7)*l**6.0
-  
+
     sigma = fac*(10.d0**p)
 
 end function p_cx_1_1_adas
-  
+
 function p_cx_1_2_adas(Erel) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=1\) state to the \(m=2\) state at energy `Erel`
     !+
     !+###Equation
@@ -266,15 +272,15 @@ function p_cx_1_2_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(9), parameter :: a = [-4.036239511d3, 6.941235312d3, &
                                                    -5.186974866d3, 2.194885201d3, &
                                                    -5.765960509d2, 9.653534186d1, &
                                                    -1.008066138d1, 6.010731909d-1,&
                                                    -1.567417031d-2 ]
     real(Float64) :: e, ee, fac, l, p
-  
+
     e = Erel*1.d3
     if(e.ge.1.d3) then
         ee = max(e,1.0)
@@ -283,19 +289,19 @@ function p_cx_1_2_adas(Erel) result(sigma)
         ee = 1.0d3
         fac = Erel**(0.5)
     endif
-  
+
     l = log10(ee)
-  
+
     p = a(1) + a(2)*l + a(3)*l**2.0 + a(4)*l**3.0 + &
         a(5)*l**4.0   + a(6)*l**5.0 + a(7)*l**6.0 + &
         a(8)*l**7.0   + a(9)*l**8.0
-  
+
     sigma = fac*(10.d0**p)
 
 end function p_cx_1_2_adas
-  
+
 function p_cx_1_3_adas(Erel) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=1\) state to the \(m=3\) state at energy `Erel`
     !+
     !+###Equation
@@ -305,15 +311,15 @@ function p_cx_1_3_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(10), parameter :: a = [7.037287586d4, -1.479161477d5, &
                                                     1.370120708d5, -7.343180122d4, &
                                                     2.509832081d4, -5.674317075d3, &
                                                     8.487767749d2, -8.102284612d1, &
                                                     4.480007503d0, -1.093512342d-1 ]
     real(Float64) :: e, ee, fac, l, p
-  
+
     e = Erel*1.d3
     if(e.ge.2.d3) then
         ee = max(e,1.0)
@@ -322,19 +328,19 @@ function p_cx_1_3_adas(Erel) result(sigma)
         ee = 2.0d3
         fac = (Erel**(1.4))/2.8
     endif
-  
+
     l = log10(ee)
-  
+
     p = a(1) + a(2)*l + a(3)*l**2.0 + a(4)*l**3.0 + &
         a(5)*l**4.0   + a(6)*l**5.0 + a(7)*l**6.0 + &
         a(8)*l**7.0   + a(9)*l**8.0 + a(10)*l**9.0
-  
+
     sigma = fac*(10.d0**p)
 
 end function p_cx_1_3_adas
-  
+
 function p_cx_1_4_adas(Erel) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=1\) state to the \(m=4\) state at energy `Erel`
     !+
     !+###Equation
@@ -344,15 +350,15 @@ function p_cx_1_4_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(10), parameter :: a = [6.826447557d4, -1.431980004d5, &
                                                     1.323968679d5, -7.083995050d4, &
                                                     2.417608863d4, -5.458418789d3, &
                                                     8.154875237d2, -7.776012846d1, &
-                                                    4.295431731d0, -1.047567211d-1 ] 
+                                                    4.295431731d0, -1.047567211d-1 ]
     real(Float64) :: e, ee, fac, l, p
-  
+
     e = Erel*1.d3
     if(e.ge.2.d3) then
         ee = max(e,1.0)
@@ -361,22 +367,22 @@ function p_cx_1_4_adas(Erel) result(sigma)
         ee = 2.0d3
         fac = (Erel**(2.0))/4.0
     endif
-  
+
     l = log10(ee)
-  
+
     p = a(1) + a(2)*l + a(3)*l**2.0 + a(4)*l**3.0 + &
         a(5)*l**4.0   + a(6)*l**5.0 + a(7)*l**6.0 + &
         a(8)*l**7.0   + a(9)*l**8.0 + a(10)*l**9.0
-  
+
     sigma = fac*(10.d0**p)
 
 end function p_cx_1_4_adas
-  
+
 function p_cx_1(Erel,m_max) result(sigma)
-    !+Calculates an array of cross section for proton-Hydrogen charge exchange interactions 
+    !+Calculates an array of cross section for proton-Hydrogen charge exchange interactions
     !+from the \(n=1\) state to m = 1..`m_max` states at energy `Erel`
     !+
-    !+@note Cross sections are normalized to the total cross sections calculated by 
+    !+@note Cross sections are normalized to the total cross sections calculated by
     !+[[p_cx_janev(proc)]]
     !+###Equation
     !+ $$H^+ + H(1) \rightarrow H(m=1..m_{max}) + H^+$$
@@ -391,7 +397,7 @@ function p_cx_1(Erel,m_max) result(sigma)
 
     integer :: i
     real(Float64) :: norm_fac
-  
+
     sigma = 0.d0
     do i=1,m_max
         select case (i)
@@ -407,15 +413,15 @@ function p_cx_1(Erel,m_max) result(sigma)
                 sigma(i) = 0.d0
         end select
     enddo
-  
+
     !Normalize to Janev
     norm_fac = p_cx_janev(Erel, 1)/sum(sigma)
     sigma = norm_fac*sigma
-  
+
 end function p_cx_1
-  
+
 function p_cx_2_2_adas(Erel) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=2\) state to the \(m=2\) state at energy `Erel`
     !+
     !+###Equation
@@ -425,15 +431,15 @@ function p_cx_2_2_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-   
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(11), parameter :: a2s = [-1.896015167d6, 4.431727330d6, &
                                                       -4.627815357d6, 2.843068107d6, &
                                                       -1.137952956d6, 3.100801094d5, &
                                                       -5.825744660d4, 7.452319142d3, &
                                                       -6.212350647d2, 3.047712749d1, &
                                                       -6.682658463d-1 ]
-  
+
     real(Float64), dimension(11), parameter :: a2p = [-1.614213508d5, 3.772469288d5, &
                                                       -3.924736424d5, 2.393127027d5, &
                                                       -9.470300966d4, 2.541276100d4, &
@@ -441,9 +447,9 @@ function p_cx_2_2_adas(Erel) result(sigma)
                                                       -4.744504549d1, 2.254460913d0, &
                                                       -4.767235839d-2 ]
     real(Float64), parameter :: n = 2.d0
-  
+
     real(Float64) :: e, ee, fac, l, sigma2s, sigma2p
-  
+
     e = Erel * 1.d3 * n**2.0
     if(Erel.le.1.5d2) then
         ee = max(e, 1.d3)
@@ -452,25 +458,25 @@ function p_cx_2_2_adas(Erel) result(sigma)
         ee = 1.5e5 * n**2.d0
         fac = 2.d15 * ((e*1.d-3)**(-5.5))
     endif
-  
+
     l = log10(ee)
-  
+
     sigma2s = a2s(1) + a2s(2)*l + a2s(3)*l**2.0 + a2s(4)*l**3.0 + &
               a2s(5)*l**4.0     + a2s(6)*l**5.0 + a2s(7)*l**6.0 + &
               a2s(8)*l**7.0     + a2s(9)*l**8.0 + a2s(10)*l**9.0 + a2s(11)*l**10.0
     sigma2s = 10.d0**(sigma2s)
-  
+
     sigma2p = a2p(1) + a2p(2)*l + a2p(3)*l**2.0 + a2p(4)*l**3.0 + &
               a2p(5)*l**4.0     + a2p(6)*l**5.0 + a2p(7)*l**6.0 + &
               a2p(8)*l**7.0     + a2p(9)*l**8.0 + a2p(10)*l**9.0 + a2p(11)*l**10.0
     sigma2p = 10.d0**(sigma2p)
-  
+
     sigma = fac*(0.25*sigma2s + 0.75*sigma2p)
 
 end function p_cx_2_2_adas
-  
+
 function p_cx_2_3_adas(Erel) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=2\) state to the \(m=3\) state at energy `Erel`
     !+
     !+###Equation
@@ -480,46 +486,46 @@ function p_cx_2_3_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-   
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(11), parameter :: a2s = [-3.513030327d5, 9.281116596d5, &
                                                       -1.086843398d6, 7.437325055d5, &
                                                       -3.296609685d5, 9.897503768d4, &
                                                       -2.039707143d4, 2.850670244d3, &
                                                       -2.587092857d2, 1.377382945d1, &
                                                       -3.268306303d-1 ]
-  
+
     real(Float64), dimension(11), parameter :: a2p = [-1.901264631d5, 5.124716103d5, &
                                                       -6.101921504d5, 4.234717934d5, &
                                                       -1.899866398d5, 5.764464326d4, &
                                                       -1.199087959d4, 1.689900512d3, &
                                                       -1.545334374d2, 8.285001228d0, &
                                                       -1.978656474d-1 ]
-  
+
     real(Float64), parameter :: n = 2.d0
-  
+
     real(Float64) :: ee, l, sigma2s, sigma2p
-  
+
     ee = max(Erel * 1.d3 * n**2.d0, 1.d3)
-  
+
     l = log10(ee)
-  
+
     sigma2s = a2s(1) + a2s(2)*l + a2s(3)*l**2.0 + a2s(4)*l**3.0 + &
               a2s(5)*l**4.0     + a2s(6)*l**5.0 + a2s(7)*l**6.0 + &
               a2s(8)*l**7.0     + a2s(9)*l**8.0 + a2s(10)*l**9.0 + a2s(11)*l**10.0
     sigma2s = 10.d0**(sigma2s)
-  
+
     sigma2p = a2p(1) + a2p(2)*l + a2p(3)*l**2.0 + a2p(4)*l**3.0 + &
               a2p(5)*l**4.0     + a2p(6)*l**5.0 + a2p(7)*l**6.0 + &
               a2p(8)*l**7.0     + a2p(9)*l**8.0 + a2p(10)*l**9.0 + a2p(11)*l**10.0
     sigma2p = 10.d0**(sigma2p)
-  
+
     sigma = (0.25*sigma2s + 0.75*sigma2p)
 
 end function p_cx_2_3_adas
-  
+
 subroutine m_spread(n, m_max, sigma_tot, sigma)
-    !+ Spreads the total charge exchange cross section, `sigma_tot`, 
+    !+ Spreads the total charge exchange cross section, `sigma_tot`,
     !+ among the non-filled m states of `sigma` according to an exponential
     integer, intent(in)                            :: n
         !+ Initial atomic energy level/state
@@ -528,21 +534,21 @@ subroutine m_spread(n, m_max, sigma_tot, sigma)
     real(Float64), intent(in)                      :: sigma_tot
         !+ Amount of "cross section" to spread about the non-filled m state of sigma
     real(Float64), dimension(m_max), intent(inout) :: sigma
-        !+ Array of cross sections from the `n` state to m=1..`m_max` [\(cm^2\)] 
+        !+ Array of cross sections from the `n` state to m=1..`m_max` [\(cm^2\)]
     real(Float64) :: En, Em
     real(Float64) :: norm_fac
     real(Float64), dimension(m_max) :: sigma_m
     integer :: m
-  
+
     sigma_m = 0.d0
     En = 13.6/(real(n)**2.0)
     do m=1,m_max
         Em = 13.6/(real(m)**2.0)
-        if(sigma(m).eq.0.d0) then 
+        if(sigma(m).eq.0.d0) then
             sigma_m(m) = (sigma_tot/sqrt(2.0*PI))*exp(-0.5*(En-Em)**2.0)
         endif
     enddo
-    
+
     norm_fac = sigma_tot/sum(sigma_m)
     do m=1,m_max
         if(sigma(m).eq.0.d0) sigma(m) = sigma_m(m)*norm_fac
@@ -550,13 +556,13 @@ subroutine m_spread(n, m_max, sigma_tot, sigma)
     enddo
 
 end subroutine m_spread
-  
+
 function p_cx_2(Erel,m_max) result(sigma)
-    !+Calculates an array of cross sections for proton-Hydrogen charge exchange interactions 
+    !+Calculates an array of cross sections for proton-Hydrogen charge exchange interactions
     !+from the \(n=2\) state to m = 1..`m_max` states at energy `Erel`
     !+
-    !+@note 
-    !+Cross sections are normalized to the total cross sections calculated by 
+    !+@note
+    !+Cross sections are normalized to the total cross sections calculated by
     !+[[p_cx_janev(proc)]].
     !+
     !+@note
@@ -577,11 +583,11 @@ function p_cx_2(Erel,m_max) result(sigma)
         !+ Number of `m` states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the index refers to the `m`'th state [\(cm^2\)]
-  
+
     real(Float64), parameter :: n2 = 4.d0
     integer :: i
     real(Float64) :: En, Em, sigma_n, norm_fac
-  
+
     sigma = 0.d0
     do i=1,min(m_max,3)
         select case (i)
@@ -594,16 +600,16 @@ function p_cx_2(Erel,m_max) result(sigma)
         end select
     enddo
     sigma_n = max(p_cx_janev(Erel, 2) - sum(sigma), 0.d0)
-  
+
     call m_spread(2,m_max,sigma_n,sigma)
-  
+
     norm_fac = p_cx_janev(Erel, 2)/sum(sigma)
     sigma = sigma*norm_fac
-  
+
 end function p_cx_2
-  
+
 function p_cx_3_2_adas(Erel) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=3\) state to the \(m=2\) state at energy `Erel`
     !+
     !+###Equation
@@ -613,18 +619,18 @@ function p_cx_3_2_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(11), parameter :: a = [-1.149224555d6, 2.750368877d6, &
                                                     -2.942222842d6, 1.852584954d6, &
                                                     -7.603284323d5, 2.125284465d5, &
                                                     -4.097580431d4, 5.380901722d3, &
                                                     -4.606297192d2, 2.321345254d1, &
                                                     -5.230186707d-1 ]
-  
+
     real(Float64), parameter :: n = 3.0
     real(Float64) :: ee, fac, l, p
-  
+
     if(Erel.lt.90.0) then
         ee = max(Erel * 1.d3 * n**2.0, 1.d3) !keV to eV
         fac = 1.d0
@@ -632,19 +638,19 @@ function p_cx_3_2_adas(Erel) result(sigma)
         ee = 90.0 * 1.d3 * n**2.0
         fac = 1.d16 * (Erel*n**2.0)**(-5.5)
     endif
-  
+
     l = log10(ee)
-  
+
     p = a(1) + a(2)*l + a(3)*l**2.0 + a(4)*l**3.0 + &
         a(5)*l**4.0   + a(6)*l**5.0 + a(7)*l**6.0 + &
         a(8)*l**7.0   + a(9)*l**8.0 + a(10)*l**9.0 + a(11)*l**10.d0
-  
+
     sigma = fac*(10.d0**p)
 
 end function p_cx_3_2_adas
-  
+
 function p_cx_3_3_adas(Erel) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=3\) state to the \(m=3\) state at energy `Erel`
     !+
     !+###Equation
@@ -654,17 +660,17 @@ function p_cx_3_3_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(10), parameter :: a = [-4.302808608d4, 9.499298161d4, &
                                                     -9.264698488d4, 5.236947172d4, &
                                                     -1.890479538d4, 4.519068626d3, &
                                                     -7.152485009d2, 7.227063167d1, &
                                                     -4.230036444d0, 1.092702525d-1 ]
-  
+
     real(Float64), parameter :: n = 3.0
     real(Float64) :: ee, fac, l, p
-  
+
     if(Erel.lt.90.0) then
         ee = max(Erel * 1.d3 * n**2.0, 1.d3) !keV to eV
         fac = 1.d0
@@ -672,19 +678,19 @@ function p_cx_3_3_adas(Erel) result(sigma)
         ee = 90.0 * 1.d3 * n**2
         fac = 0.85d16 *(Erel*n**2.0)**(-5.5)
     endif
-  
+
     l = log10(ee)
-  
+
     p = a(1) + a(2)*l + a(3)*l**2.0 + a(4)*l**3.0 + &
         a(5)*l**4.0   + a(6)*l**5.0 + a(7)*l**6.0 + &
         a(8)*l**7.0   + a(9)*l**8.0 + a(10)*l**9.0
-  
+
     sigma = fac*(10.d0**p)
-  
+
 end function p_cx_3_3_adas
-  
+
 function p_cx_3_4_adas(Erel) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=3\) state to the \(m=4\) state at energy `Erel`
     !+
     !+###Equation
@@ -694,8 +700,8 @@ function p_cx_3_4_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(9), parameter :: a = [ 1.705303425d4,-3.316878090d4, &
                                                     2.792556433d4,-1.330264490d4, &
                                                     3.921666688d3,-7.327555138d2, &
@@ -703,7 +709,7 @@ function p_cx_3_4_adas(Erel) result(sigma)
                                                     1.577120745d-1 ]
     real(Float64), parameter :: n = 3.0
     real(Float64) :: ee, fac, l, p
-  
+
     if(Erel.lt.90.0) then
         ee = max(Erel * 1.d3 * n**2.0, 1.d3) !keV to eV
         fac = 1.d0
@@ -711,19 +717,19 @@ function p_cx_3_4_adas(Erel) result(sigma)
         ee = 90.0 * 1.d3 * n**2.0
         fac = 0.82d16 *(Erel*n**2.0)**(-5.5)
     endif
-  
+
     l = log10(ee)
-  
+
     p = a(1) + a(2)*l + a(3)*l**2.0 + a(4)*l**3.0 + &
         a(5)*l**4.0   + a(6)*l**5.0 + a(7)*l**6.0 + &
         a(8)*l**7.0   + a(9)*l**8.0
-  
+
     sigma = fac*(10.d0**p)
-    
+
 end function p_cx_3_4_adas
-  
+
 function p_cx_3_5_adas(Erel) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=3\) state to the \(m=5\) state at energy `Erel`
     !+
     !+###Equation
@@ -733,8 +739,8 @@ function p_cx_3_5_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(11), parameter :: a = [-2.786268232d2, 4.269683825d4, &
                                                     -8.973561028d4, 8.365732310d4, &
                                                     -4.524587937d4, 1.563630402d4, &
@@ -743,22 +749,22 @@ function p_cx_3_5_adas(Erel) result(sigma)
                                                     -7.362649692d-2 ]
     real(Float64), parameter :: n = 3.0
     real(Float64) :: ee, fac, l, p
-  
+
     ee = max(Erel * 1.d3 * n**2.0, 1.d3) !keV to eV
     fac = 1.d0
-  
+
     l = log10(ee)
-  
+
     p = a(1) + a(2)*l + a(3)*l**2.0 + a(4)*l**3.0 + &
         a(5)*l**4.0   + a(6)*l**5.0 + a(7)*l**6.0 + &
         a(8)*l**7.0   + a(9)*l**8.0 + a(10)*l**9.0 + a(11)*l**10.0
-  
+
     sigma = fac*(10.d0**p)
-  
+
 end function p_cx_3_5_adas
-  
+
 function p_cx_3_6inf_adas(Erel) result(sigma)
-    !+Calculates total cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates total cross section for a proton-Hydrogen charge exchange interaction
     !+from the \(n=3\) state to \(\forall \; m \geq 6\) states at energy `Erel`
     !+
     !+###Equation
@@ -768,8 +774,8 @@ function p_cx_3_6inf_adas(Erel) result(sigma)
     real(Float64), intent(in) :: Erel
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(11), parameter :: a = [ 7.146969470d5,-1.665413326d6, &
                                                      1.735840441d6,-1.065792786d6, &
                                                      4.269334710d5,-1.165954977d5, &
@@ -778,7 +784,7 @@ function p_cx_3_6inf_adas(Erel) result(sigma)
                                                      2.596865877d-1 ]
     real(Float64), parameter :: n = 3.0
     real(Float64) :: ee, fac, l, p
-  
+
     if(Erel.lt.90.0) then
         ee = max(Erel * 1.d3 * n**2.0, 1.d3) !keV to eV
         fac = 1.d0
@@ -786,23 +792,23 @@ function p_cx_3_6inf_adas(Erel) result(sigma)
         ee = 90.0 * 1.d3 * n**2.0
         fac = 2.d20 *(Erel*n**2.0)**(-7.0)
     endif
-  
+
     l = log10(ee)
-  
+
     p = a(1) + a(2)*l + a(3)*l**2.0 + a(4)*l**3.0 + &
         a(5)*l**4.0   + a(6)*l**5.0 + a(7)*l**6.0 + &
         a(8)*l**7.0   + a(9)*l**8.0 + a(10)*l**9.0 + a(11)*l**10.0
-  
+
     sigma = fac*(10.d0**p)
-  
+
 end function p_cx_3_6inf_adas
-  
+
 function p_cx_3(Erel,m_max) result(sigma)
-    !+Calculates an array of cross sections for proton-Hydrogen charge exchange interactions 
+    !+Calculates an array of cross sections for proton-Hydrogen charge exchange interactions
     !+from the \(n=3\) state to m = 1..`m_max` states at energy `Erel`
     !+
-    !+@note 
-    !+Cross sections are normalized to the total cross sections calculated by 
+    !+@note
+    !+Cross sections are normalized to the total cross sections calculated by
     !+[[p_cx_janev(proc)]].
     !+
     !+@note
@@ -823,44 +829,44 @@ function p_cx_3(Erel,m_max) result(sigma)
         !+ Number of `m` states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the index refers to the `m`'th state [\(cm^2\)]
-  
+
     real(Float64), parameter :: n2 = 9.d0
     real(Float64) :: eb, En, Em, sigma_m6, norm_fac
     real(Float64), dimension(m_max) :: sigma1
-  
+
     sigma = 0.d0
     sigma1 = 0.d0
     sigma1 = p_cx_1(Erel*n2,m_max)
     sigma(1) = p_cx_1_3_adas(Erel*n2)/n2
-  
+
     sigma(2) = p_cx_3_2_adas(Erel)
     sigma(3) = p_cx_3_3_adas(Erel)
     sigma(4) = p_cx_3_4_adas(Erel)
-  
+
     if(m_max.ge.5) then
         sigma(5) = p_cx_3_5_adas(Erel)
     endif
-  
+
     if(m_max.ge.6) then
         sigma_m6 = p_cx_3_6inf_adas(Erel)
         call m_spread(3, m_max, sigma_m6, sigma)
     endif
-  
+
     norm_fac = p_cx_janev(Erel, 3)/sum(sigma)
     sigma = sigma*norm_fac
-  
+
 end function p_cx_3
-  
+
 function p_cx_n(Erel, n, m_max) result(sigma)
-    !+Calculates an array of cross sections for proton-Hydrogen charge exchange interactions 
+    !+Calculates an array of cross sections for proton-Hydrogen charge exchange interactions
     !+from the `n` state to m = 1..`m_max` states at energy `Erel`
     !+
-    !+@note 
-    !+Cross sections are normalized to the total cross sections calculated by 
+    !+@note
+    !+Cross sections are normalized to the total cross sections calculated by
     !+[[p_cx_janev(proc)]].
     !+
     !+@note
-    !+Cross sections for some transitions are calculated via the equivalence principle or 
+    !+Cross sections for some transitions are calculated via the equivalence principle or
     !+by "spreading" their expected total cross sections among the non-filled m states.
     !+
     !+###Equation
@@ -875,10 +881,10 @@ function p_cx_n(Erel, n, m_max) result(sigma)
         !+ Number of `m` states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the index refers to the `m`'th state [\(cm^2\)]
-  
+
     real(Float64), dimension(m_max) :: sigma2,sigma3
     real(Float64) :: sigma_n,e,norm_fac
-  
+
     sigma = 0.d0
     select case (n)
         case (0)
@@ -910,18 +916,18 @@ function p_cx_n(Erel, n, m_max) result(sigma)
             sigma3 = p_cx_3(e/(3.0**2.0),m_max)*(3.d0/n)**2.0
             sigma(3) = sigma3(6)
         case DEFAULT
-    end select 
-  
+    end select
+
     sigma_n = max(p_cx_janev(Erel,n) - sum(sigma),0.0)
     call m_spread(n, m_max, sigma_n, sigma)
-  
+
     norm_fac = p_cx_janev(Erel, n)/sum(sigma)
     sigma = norm_fac*sigma
-  
+
 end function p_cx_n
-  
+
 function p_cx_n_m(Erel, n, m) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen charge exchange interaction 
+    !+Calculates cross section for a proton-Hydrogen charge exchange interaction
     !+from the `n` state to the `m` state at energy `Erel`
     !+
     !+###Equation
@@ -935,22 +941,22 @@ function p_cx_n_m(Erel, n, m) result(sigma)
     integer, intent(in)       :: m
         !+ Final atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     integer :: m_max = 12
     real(Float64), dimension(12) :: sigma_m
-  
+
     sigma_m = p_cx_n(Erel, n, m_max)
     if(m.le.0) then
         sigma = sum(sigma_m)
     else
         sigma = sigma_m(m)
     endif
-  
+
 end function p_cx_n_m
-  
+
 function p_cx(Erel, n_max, m_max) result(sigma)
-    !+Calculates a matrix of cross sections for proton-Hydrogen charge exchange interactions 
+    !+Calculates a matrix of cross sections for proton-Hydrogen charge exchange interactions
     !+from the \(n=1..n_{max} \rightarrow m=1..m_{max}\) states at energy `Erel`
     !+
     !+###Equation
@@ -965,23 +971,23 @@ function p_cx(Erel, n_max, m_max) result(sigma)
         !+ Number of final atomic energy levels/states
     real(Float64), dimension(n_max,m_max) :: sigma
         !+ Matrix of cross sections where the subscripts correspond
-        !+ to the \(n \rightarrow m\) transitions: p_cx[n,m] [\(cm^2\)] 
-  
+        !+ to the \(n \rightarrow m\) transitions: p_cx[n,m] [\(cm^2\)]
+
     real(Float64), dimension(12,12) :: sigma_full
-  
+
     integer :: n, m
-  
+
     do n=1,12
         sigma_full(n,:) = p_cx_n(Erel, n, 12)
     enddo
-  
+
     sigma = sigma_full(1:n_max,1:m_max)
 
 end function p_cx
-  
+
 !proton-Hydrogen impact ionization
 function p_ioniz_1_janev(eb) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen impact ionization interaction 
+    !+Calculates cross section for a proton-Hydrogen impact ionization interaction
     !+from the \(n=1\) state at energy `eb`
     !+
     !+###Equation
@@ -991,18 +997,18 @@ function p_ioniz_1_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(8), parameter :: b = [2.0160d-3, 3.7154d0,  &
                                                    3.9890d-2, 3.1413d-1, &
                                                    2.1254d0,  6.3990d3,  &
                                                    6.1897d1,  9.2731d3 ]
         !+ Fitting Parameters from Table 8 in Ref. 2
-  
+
     real(Float64), parameter :: n2 = 1.d0
     real(Float64) :: Ehat
     real(Float64) :: p1, p2, p3
-  
+
     Ehat = eb*n2
     p1 = b(1)*(n2)**2.0
     p2 = Ehat**b(2) * exp(-b(3)*Ehat) / (1.d0 + b(4)*Ehat**b(5))
@@ -1010,9 +1016,9 @@ function p_ioniz_1_janev(eb) result(sigma)
     sigma = 1.0d-16 * p1 * (p2 + p3)
 
 end function p_ioniz_1_janev
-  
+
 function p_ioniz_2_omullane(eb) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen impact ionization interaction 
+    !+Calculates cross section for a proton-Hydrogen impact ionization interaction
     !+from the \(n=2\) state at energy `eb`
     !+
     !+###Equation
@@ -1022,27 +1028,27 @@ function p_ioniz_2_omullane(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(8), parameter :: b = [3.9330d-3, 1.8188d0,  &
                                                    1.8870d-2, 6.7489d-3, &
                                                    1.3768d0, 6.8852d2,   &
                                                    9.6435d1, 5.6515d23 ]
         !+ Fitting Parameters from Table 1 in Ref. 3
-  
+
     real(Float64), parameter :: n2 = 4.d0
     real(Float64) :: Ehat
     real(Float64) :: p1, p2, p3
-  
+
     Ehat = eb*n2
     p1 = b(1)*(n2)**2.0
     p2 = Ehat**b(2) * exp(-b(3)*Ehat) / (1.d0 + b(4)*Ehat**b(5))
     p3 = (b(6)* exp(-b(7)/Ehat) *log(1.d0  +b(8)*Ehat) ) /Ehat
     sigma = 1.0d-16 * p1 * (p2 + p3)
-  
+
 end function p_ioniz_2_omullane
-  
+
 function p_ioniz_3_omullane(eb) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen impact ionization interaction 
+    !+Calculates cross section for a proton-Hydrogen impact ionization interaction
     !+from the \(n=3\) state at energy `eb`
     !+
     !+###Equation
@@ -1052,27 +1058,27 @@ function p_ioniz_3_omullane(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(8), parameter :: b = [1.1076d-2, 1.6197d0,  &
                                                    6.7154d-3, 5.1188d-3, &
                                                    1.8549d0,  2.3696d2,  &
                                                    7.8286d1,  1.0926d23 ]
         !+ Fitting Parameters from Table 1 in Ref. 3
-  
+
     real(Float64), parameter :: n2 = 9.d0
     real(Float64) :: Ehat
     real(Float64) :: p1, p2, p3
-  
+
     Ehat = eb*n2
     p1 = b(1)*(n2)**2.0
     p2 = Ehat**b(2) * exp(-b(3)*Ehat) / (1.d0 + b(4)*Ehat**b(5))
     p3 = (b(6)* exp(-b(7)/Ehat) *log(1.d0  +b(8)*Ehat) ) /Ehat
     sigma = 1.0d-16 * p1 * (p2 + p3)
-  
+
 end function p_ioniz_3_omullane
-  
+
 function p_ioniz_4_omullane(eb) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen impact ionization interaction 
+    !+Calculates cross section for a proton-Hydrogen impact ionization interaction
     !+from the \(n=4\) state at energy `eb`
     !+
     !+###Equation
@@ -1082,27 +1088,27 @@ function p_ioniz_4_omullane(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(8), parameter :: b = [1.1033d-2, 1.6281d0,  &
                                                    5.5955d-3, 7.2023d-3, &
                                                    1.7358d0,  2.2755d2,  &
                                                    8.6339d1,  3.9151d29 ]
         !+ Fitting Parameters from Table 1 in Ref. 3
-  
+
     real(Float64), parameter :: n2 = 16.d0
     real(Float64) :: Ehat
     real(Float64) :: p1, p2, p3
-  
+
     Ehat = eb*n2
     p1 = b(1)*(n2)**2.0
     p2 = Ehat**b(2) * exp(-b(3)*Ehat) / (1.d0 + b(4)*Ehat**b(5))
     p3 = (b(6)* exp(-b(7)/Ehat) *log(1.d0  +b(8)*Ehat) ) /Ehat
     sigma = 1.0d-16 * p1 * (p2 + p3)
-  
+
 end function p_ioniz_4_omullane
-  
+
 function p_ioniz_5_omullane(eb) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen impact ionization interaction 
+    !+Calculates cross section for a proton-Hydrogen impact ionization interaction
     !+from the \(n=5\) state at energy `eb`
     !+
     !+###Equation
@@ -1112,27 +1118,27 @@ function p_ioniz_5_omullane(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(8), parameter :: b = [1.1297d-2, 1.8685d0,  &
                                                    1.5038d-2, 1.1195d-1, &
                                                    1.0538d0,  8.6096d2,  &
                                                    8.9939d1,  1.9249d4 ]
         !+ Fitting Parameters from Table 1 in Ref. 3
-  
+
     real(Float64), parameter :: n2 = 25.d0
     real(Float64) :: Ehat
     real(Float64) :: p1, p2, p3
-  
+
     Ehat = eb*n2
     p1 = b(1)*(n2)**2.0
     p2 = Ehat**b(2) * exp(-b(3)*Ehat) / (1.d0 + b(4)*Ehat**b(5))
     p3 = (b(6)* exp(-b(7)/Ehat) *log(1.d0  +b(8)*Ehat) ) /Ehat
     sigma = 1.0d-16 * p1 * (p2 + p3)
-  
+
 end function p_ioniz_5_omullane
 
 function p_ioniz_n(eb,n) result(sigma)
-    !+Calculates cross section for a proton-Hydrogen impact ionization interaction 
+    !+Calculates cross section for a proton-Hydrogen impact ionization interaction
     !+from the `n`th state at energy `eb`
     !+
     !+###Equation
@@ -1145,8 +1151,8 @@ function p_ioniz_n(eb,n) result(sigma)
     integer, intent(in)       :: n
         !+ Initial atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     select case (n)
         case (0)
             stop
@@ -1163,9 +1169,9 @@ function p_ioniz_n(eb,n) result(sigma)
     end select
 
 end function p_ioniz_n
-  
+
 function p_ioniz(eb,n_max) result(sigma)
-    !+Calculates an array of cross sections for proton-Hydrogen impact ionization interactions 
+    !+Calculates an array of cross sections for proton-Hydrogen impact ionization interactions
     !+from the n = 1..`n_max` state at energy `eb`
     !+
     !+###Equation
@@ -1179,15 +1185,15 @@ function p_ioniz(eb,n_max) result(sigma)
         !+ Number of initial atomic energy level/state
     real(Float64), dimension(n_max) :: sigma
         !+ Array of cross sections where the index refers to the `n`'th state [\(cm^2\)]
-  
+
     integer :: i
-  
+
     do i=1,n_max
         sigma(i) = p_ioniz_n(eb,i)
     enddo
 
 end function p_ioniz
-  
+
 !! proton-Hydrogen impact excitation
 function p_excit_1_2_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
@@ -1202,20 +1208,20 @@ function p_excit_1_2_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(10), parameter :: a = [34.433d0, 8.5476d0,  &
                                                     7.8501d0, -9.2217d0, &
                                                     1.8020d-2, 1.6931d0, &
                                                     1.9422d-3, 2.9068d0, &
                                                     44.507d0, 0.56870d0 ]
         !+ Fitting parameters from Table 4 in Ref. 2
-      
-    sigma = 1.d-16 * a(1) * ( a(2)*exp(-a(3)*eb)/(eb**a(4)) + & 
+
+    sigma = 1.d-16 * a(1) * ( a(2)*exp(-a(3)*eb)/(eb**a(4)) + &
                      a(5)*exp(-a(6)/eb)/(1.+a(7)*eb**a(8))  + &
                      exp(-a(9)/eb)*log(1.+a(10)*eb)/eb )
 
 end function p_excit_1_2_janev
-  
+
 function p_excit_1_3_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=1\) state to the \(m=3\) state at energy `eb`
@@ -1229,19 +1235,19 @@ function p_excit_1_3_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(8), parameter :: b = [ 6.1950d0, 5.5162d-3,  &
                                                     0.29114d0, -4.5264d0, &
                                                     6.0311d0, -2.0679d0,  &
                                                     35.773d0, 0.54818d0 ]
         !+ Fitting parameters from Table 5 in Ref. 2
-    
+
     sigma = 1.d-16 * b(1) * (b(2)*exp(-b(3)*eb)/ &
                      (eb**b(4)+b(5)*eb**b(6)) + &
                      exp(-b(7)/eb)*log(1.+b(8)*eb)/eb)
-  
+
 end function p_excit_1_3_janev
-  
+
 function p_excit_1_4_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=1\) state to the \(m=4\) state at energy `eb`
@@ -1255,19 +1261,19 @@ function p_excit_1_4_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(8), parameter :: b = [2.0661d0, 5.1335d-4,  &
                                                    0.28953d0, -2.2849d0, &
                                                    0.11528d0, -4.8970d0, &
                                                    34.975d0, 0.91213d0 ]
         !+ Fitting parameters from Table 5 in Ref. 2
-  
+
     sigma = 1.d-16 * b(1) * (b(2)*exp(-b(3)*eb)/ &
                      (eb**b(4)+b(5)*eb**b(6)) + &
                      exp(-b(7)/eb)*log(1.+b(8)*eb)/eb)
-  
+
 end function p_excit_1_4_janev
-  
+
 function p_excit_1_5_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=1\) state to the \(m=5\) state at energy `eb`
@@ -1281,19 +1287,19 @@ function p_excit_1_5_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(8), parameter :: b = [1.2449d0, 3.0826d-4,   &
                                                    0.31063d0, -2.4161d0,  &
                                                    0.024664d0, -6.3726d0, &
                                                    32.291d0, 0.21176d0 ]
         !+ Fitting parameters from Table 5 in Ref. 2
-  
+
     sigma = 1.d-16 * b(1) * (b(2)*exp(-b(3)*eb)/ &
                      (eb**b(4)+b(5)*eb**b(6)) + &
                      exp(-b(7)/eb)*log(1.+b(8)*eb)/eb)
-  
+
 end function p_excit_1_5_janev
-  
+
 function p_excit_1_6_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=1\) state to the \(m=6\) state at energy `eb`
@@ -1307,19 +1313,19 @@ function p_excit_1_6_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(8), parameter :: b = [0.63771d0, 3.2949d-4,  &
                                                    0.25757d0, -2.2950d0,  &
                                                    0.050796d0, -5.5986d0, &
                                                    37.174d0, 0.39265d0 ]
         !+ Fitting parameters from Table 5 in Ref. 2
-  
+
     sigma = 1.d-16 * b(1) * (b(2)*exp(-b(3)*eb)/ &
                      (eb**b(4)+b(5)*eb**b(6)) + &
                      exp(-b(7)/eb)*log(1.+b(8)*eb)/eb)
-  
+
 end function p_excit_1_6_janev
-  
+
 function p_excit_1_janev(eb, m_max) result(sigma)
     !+Calculates an array of cross sections for a proton-Hydrogen impact excitation transitions from
     !+the \(n=1\) state to the \(m=1..{m_max}\) state at energy `eb`
@@ -1338,11 +1344,11 @@ function p_excit_1_janev(eb, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refer to the transition
-        !+ from \(n=1\) to m [\(cm^2\)] 
+        !+ from \(n=1\) to m [\(cm^2\)]
 
     integer :: m
     sigma = 0.d0
-  
+
     do m=1,m_max
         select case (m)
             case (1)
@@ -1361,9 +1367,9 @@ function p_excit_1_janev(eb, m_max) result(sigma)
                 sigma(m) = p_excit_1_6_janev(eb)*(6.0/real(m))**3.0
         end select
     enddo
-  
+
 end function p_excit_1_janev
-  
+
 function p_excit_2_3_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=2\) state to the \(m=3\) state at energy `eb`
@@ -1377,17 +1383,17 @@ function p_excit_2_3_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(6), parameter :: c = [394.51d0, 0.013597d0, &
                                                    0.16565d0, -0.8949d0, &
                                                    21.606d0,  0.62426d0  ]
         !+ Fitting parameters from Table 6 in Ref. 2
-  
+
     sigma = 1.d-16 * c(1)*(c(2)*exp(-c(3)*eb)/(eb**c(4)) + &
                      exp(-c(5)/eb)*log(1.+c(6)*eb)/eb)
-  
+
 end function p_excit_2_3_janev
-  
+
 function p_excit_2_4_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=2\) state to the \(m=4\) state at energy `eb`
@@ -1401,17 +1407,17 @@ function p_excit_2_4_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(6), parameter :: c = [50.744d0, 0.014398d0, &
                                                    0.31584d0, -1.4799d0, &
                                                    19.416d0,   4.0262d0  ]
         !+ Fitting parameters from Table 6 in Ref. 2
-  
+
     sigma = 1.d-16 * c(1)*(c(2)*exp(-c(3)*eb)/(eb**c(4)) + &
                      exp(-c(5)/eb)*log(1.+c(6)*eb)/eb)
-  
+
 end function p_excit_2_4_janev
-  
+
 function p_excit_2_5_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=2\) state to the \(m=5\) state at energy `eb`
@@ -1425,17 +1431,17 @@ function p_excit_2_5_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(6), parameter :: c = [18.264d0, 0.013701d0, &
                                                    0.31711d0, -1.4775d0, &
                                                    18.973d0,   2.9056d0  ]
         !+ Fitting parameters from Table 6 in Ref. 2
-  
+
     sigma = 1.d-16 * c(1)*(c(2)*exp(-c(3)*eb)/(eb**c(4)) + &
                      exp(-c(5)/eb)*log(1.+c(6)*eb)/eb)
-  
+
 end function p_excit_2_5_janev
-  
+
 function p_excit_2_6_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=2\) state to the \(m=6\) state at energy `eb`
@@ -1449,14 +1455,14 @@ function p_excit_2_6_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 4.61d-1
-  
+
     sigma = A*p_excit_2_5_janev(eb)
-  
+
 end function p_excit_2_6_janev
-  
+
 function p_excit_2_7_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=2\) state to the \(m=7\) state at energy `eb`
@@ -1470,14 +1476,14 @@ function p_excit_2_7_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 2.475d-1
-  
+
     sigma = A*p_excit_2_5_janev(eb)
-  
+
 end function p_excit_2_7_janev
-  
+
 function p_excit_2_8_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=2\) state to the \(m=8\) state at energy `eb`
@@ -1491,14 +1497,14 @@ function p_excit_2_8_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 1.465d-1
-  
+
     sigma = A*p_excit_2_5_janev(eb)
-  
+
 end function p_excit_2_8_janev
-  
+
 function p_excit_2_9_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=2\) state to the \(m=9\) state at energy `eb`
@@ -1512,14 +1518,14 @@ function p_excit_2_9_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 9.2d-2
-  
+
     sigma = A*p_excit_2_5_janev(eb)
-  
+
 end function p_excit_2_9_janev
-  
+
 function p_excit_2_10_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=2\) state to the \(m=10\) state at energy `eb`
@@ -1533,14 +1539,14 @@ function p_excit_2_10_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 6.05d-2
-  
+
     sigma = A*p_excit_2_5_janev(eb)
-  
+
 end function p_excit_2_10_janev
-  
+
 function p_excit_2_janev(eb, m_max) result(sigma)
     !+Calculates an array of cross sections for a proton-Hydrogen impact excitation transitions from
     !+the \(n=2\) state to the \(m=1..{m_max}\) state at energy `eb`
@@ -1559,11 +1565,11 @@ function p_excit_2_janev(eb, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refer to the transition
-        !+ from \(n=2\) to m [\(cm^2\)] 
-  
+        !+ from \(n=2\) to m [\(cm^2\)]
+
     integer :: m
     sigma = 0.d0
-  
+
     do m=1,m_max
         select case (m)
             case (1)
@@ -1590,9 +1596,9 @@ function p_excit_2_janev(eb, m_max) result(sigma)
                 sigma(m) = sigma(10)*(10.0/real(m))**3.0
         end select
     enddo
-  
+
 end function p_excit_2_janev
-  
+
 function p_excit_3_4_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=3\) state to the \(m=4\) state at energy `eb`
@@ -1606,17 +1612,17 @@ function p_excit_3_4_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(6), parameter :: c = [1247.5d0,  0.068781d0, &
                                                    0.521176d0, -1.2722d0, &
-                                                   11.319d0,    2.6235d0  ]  
+                                                   11.319d0,    2.6235d0  ]
         !+ Fitting parameters from Table 7 in Ref. 2
-  
+
     sigma = 1.d-16 * c(1)*(c(2)*exp(-c(3)*eb)/(eb**c(4)) + &
                      exp(-c(5)/eb)*log(1.+c(6)*eb)/eb)
-  
+
 end function p_excit_3_4_janev
-  
+
 function p_excit_3_5_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=3\) state to the \(m=5\) state at energy `eb`
@@ -1630,17 +1636,17 @@ function p_excit_3_5_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(6), parameter :: c = [190.59d0, 0.073307d0, &
-                                                   0.54177d0, -1.2894d0, &  
+                                                   0.54177d0, -1.2894d0, &
                                                    11.096d0,   2.9098d0  ]
         !+ Fitting parameters from Table 7 in Ref. 2
-  
+
     sigma = 1.d-16 * c(1)*(c(2)*exp(-c(3)*eb)/(eb**c(4)) + &
                      exp(-c(5)/eb)*log(1.+c(6)*eb)/eb)
-  
+
 end function p_excit_3_5_janev
-  
+
 function p_excit_3_6_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=3\) state to the \(m=6\) state at energy `eb`
@@ -1654,17 +1660,17 @@ function p_excit_3_6_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
+        !+ Cross Section [\(cm^2\)]
     real(Float64), dimension(6), parameter :: c = [63.494d0, 0.077953d0, &
                                                    0.53461d0, -1.2881d0, &
                                                    11.507d0,   4.3417d0  ]
         !+ Fitting parameters from Table 7 in Ref. 2
-  
+
     sigma = 1.d-16 * c(1)*(c(2)*exp(-c(3)*eb)/(eb**c(4)) + &
                      exp(-c(5)/eb)*log(1.+c(6)*eb)/eb)
-  
+
 end function p_excit_3_6_janev
-  
+
 function p_excit_3_7_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=3\) state to the \(m=7\) state at energy `eb`
@@ -1678,14 +1684,14 @@ function p_excit_3_7_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-    
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 4.67d-1
-  
+
     sigma = A*p_excit_3_6_janev(eb)
-  
+
 end function p_excit_3_7_janev
-  
+
 function p_excit_3_8_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=3\) state to the \(m=8\) state at energy `eb`
@@ -1699,14 +1705,14 @@ function p_excit_3_8_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-    
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 2.545d-1
-  
+
     sigma = A*p_excit_3_6_janev(eb)
-  
+
 end function p_excit_3_8_janev
-  
+
 function p_excit_3_9_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=3\) state to the \(m=9\) state at energy `eb`
@@ -1720,14 +1726,14 @@ function p_excit_3_9_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-    
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 1.54d-1
-  
+
     sigma = A*p_excit_3_6_janev(eb)
-  
+
 end function p_excit_3_9_janev
-  
+
 function p_excit_3_10_janev(eb) result(sigma)
     !+Calculates cross section for a proton-Hydrogen impact excitation transition from
     !+the \(n=3\) state to the \(m=10\) state at energy `eb`
@@ -1741,14 +1747,14 @@ function p_excit_3_10_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-    
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 1.0d-1
-  
+
     sigma = A*p_excit_3_6_janev(eb)
-  
+
 end function p_excit_3_10_janev
-  
+
 function p_excit_3_janev(eb, m_max) result(sigma)
     !+Calculates an array of cross sections for proton-Hydrogen impact excitation transitions from
     !+the \(n=3\) state to the \(m=1..{m_max}\) state at energy `eb`
@@ -1767,11 +1773,11 @@ function p_excit_3_janev(eb, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refer to the transition
-        !+ from \(n=3\) to m [\(cm^2\)] 
-  
+        !+ from \(n=3\) to m [\(cm^2\)]
+
     integer :: m
     sigma = 0.d0
-  
+
     do m=1,m_max
         select case (m)
             case (1)
@@ -1798,9 +1804,9 @@ function p_excit_3_janev(eb, m_max) result(sigma)
                 sigma(m) = sigma(10)*(10.0/real(m))**3.0
         end select
     enddo
-  
+
 end function p_excit_3_janev
-  
+
 function p_excit_n(eb, n, m_max) result(sigma)
     !+Calculates an array of cross sections for a proton-Hydrogen impact excitation transitions from
     !+the `n` state to the \(m=1..{m_max}\) state at energy `eb`
@@ -1818,7 +1824,7 @@ function p_excit_n(eb, n, m_max) result(sigma)
     !+* Eq. 35 and Table 7 in Ref. 2 for \(n = 3\) and \(m \le 6\) [[atomic_tables(module)]]
     !+* Eq. 36 and Table 7 in Ref. 2 for \(n = 3\) and \(m = 7-10\) [[atomic_tables(module)]]
     !+* Eq. 37 and Table 7 in Ref. 2 for \(n = 3\) and \(m \gt 10\) [[atomic_tables(module)]]
-    !+* Eq. 38-39 in Ref. 2 for \(n \gt 3\) and \(m \gt 4\) [[atomic_tables(module)]] 
+    !+* Eq. 38-39 in Ref. 2 for \(n \gt 3\) and \(m \gt 4\) [[atomic_tables(module)]]
     !+
     real(Float64), intent(in)       :: eb
         !+ Relative collision energy [keV/amu]
@@ -1828,13 +1834,13 @@ function p_excit_n(eb, n, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refer to the transition
-        !+ from `n` to m [\(cm^2\)] 
-  
+        !+ from `n` to m [\(cm^2\)]
+
     integer :: m
-    real(Float64) :: nf, mf, Etil, s, D, A, G, L, F 
+    real(Float64) :: nf, mf, Etil, s, D, A, G, L, F
     real(Float64) :: y, zpl, zmi, C2pl, C2mi, H
     sigma = 0.d0
-  
+
     select case (n)
         case (0)
             stop
@@ -1861,7 +1867,7 @@ function p_excit_n(eb, n, m_max) result(sigma)
                 G = 0.5*( Etil*nf**2.0/(mf - 1.0/mf) )**3.
                 L = log(1.0 + 0.53*Etil**2.0 * nf*(mf - 2.0/mf)/(1.0 + 0.4*Etil))
                 F = ( 1.0 - 0.3*s*D/(nf*mf) )**(1.0 + 2.0*s)
-         
+
                 y = 1.0/( 1.0 - D*log(18*s)/(4.0*s) )
                 zpl = 2.0/(Etil * nf**2 * ( (2.0 - (nf/mf)**2)**0.5 + 1.0))
                 zmi = 2.0/(Etil * nf**2 * ( (2.0 - (nf/mf)**2)**0.5 - 1.0))
@@ -1873,9 +1879,9 @@ function p_excit_n(eb, n, m_max) result(sigma)
                 sigma(m) = ((8.8d-17*n**4)/Etil)*(A*L*D + F*G*H)
             enddo m_loop
     end select
-  
+
 end function p_excit_n
-  
+
 function p_excit_n_m(eb, n, m) result(sigma)
     !+Calculates the cross section for a proton-Hydrogen impact excitation transition from
     !+the `n` state to the `m` state at energy `eb`
@@ -1893,7 +1899,7 @@ function p_excit_n_m(eb, n, m) result(sigma)
     !+* Eq. 35 and Table 7 in Ref. 2 for \(n = 3\) and \(m \le 6\) [[atomic_tables(module)]]
     !+* Eq. 36 and Table 7 in Ref. 2 for \(n = 3\) and \(m = 7-10\) [[atomic_tables(module)]]
     !+* Eq. 37 and Table 7 in Ref. 2 for \(n = 3\) and \(m \gt 10\) [[atomic_tables(module)]]
-    !+* Eq. 38-39 in Ref. 2 for \(n \gt 3\) and \(m \gt 4\) [[atomic_tables(module)]] 
+    !+* Eq. 38-39 in Ref. 2 for \(n \gt 3\) and \(m \gt 4\) [[atomic_tables(module)]]
     !+
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
@@ -1902,19 +1908,19 @@ function p_excit_n_m(eb, n, m) result(sigma)
     integer, intent(in)       :: m
         !+ Final atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)] 
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(12) :: sigma_m
-  
+
     sigma_m = p_excit_n(eb, n, 12)
     if(m.le.0) then
         sigma = sum(sigma_m)
     else
         sigma = sigma_m(m)
     endif
-  
+
 end function p_excit_n_m
-  
+
 function p_excit(eb, n_max, m_max) result(sigma)
     !+Calculates a matrix of cross sections for a proton-Hydrogen impact excitation transitions
     !+from the \(n=1..n_{max} \rightarrow m=1..m_{max}\) states at energy `eb`
@@ -1932,7 +1938,7 @@ function p_excit(eb, n_max, m_max) result(sigma)
     !+* Eq. 35 and Table 7 in Ref. 2 for \(n = 3\) and \(m \le 6\) [[atomic_tables(module)]]
     !+* Eq. 36 and Table 7 in Ref. 2 for \(n = 3\) and \(m = 7-10\) [[atomic_tables(module)]]
     !+* Eq. 37 and Table 7 in Ref. 2 for \(n = 3\) and \(m \gt 10\) [[atomic_tables(module)]]
-    !+* Eq. 38-39 in Ref. 2 for \(n \gt 3\) and \(m \gt 4\) [[atomic_tables(module)]] 
+    !+* Eq. 38-39 in Ref. 2 for \(n \gt 3\) and \(m \gt 4\) [[atomic_tables(module)]]
     !+
     real(Float64), intent(in)             :: eb
         !+ Relative collision energy [keV/amu]
@@ -1942,20 +1948,20 @@ function p_excit(eb, n_max, m_max) result(sigma)
         !+ Number of final atomic energy levels/states
     real(Float64), dimension(n_max,m_max) :: sigma
         !+ Matrix of cross sections where the subscripts correspond
-        !+ to the \(n \rightarrow m\) transitions: p_excit[n,m] [\(cm^2\)] 
-  
+        !+ to the \(n \rightarrow m\) transitions: p_excit[n,m] [\(cm^2\)]
+
     real(Float64), dimension(12,12) :: sigma_full
-  
+
     integer :: n, m
-  
+
     do n=1,12
         sigma_full(n,:) = p_excit_n(eb, n, 12)
     enddo
-  
+
     sigma = sigma_full(1:n_max,1:m_max)
 
 end function p_excit
-  
+
 function e_ioniz_1_janev(eb) result(sigma)
     !+Calculates cross section for a electron-Hydrogen impact ionization from
     !+the \(n=1\) state at energy `eb`
@@ -1969,7 +1975,7 @@ function e_ioniz_1_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Collision energy [keV]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
+        !+ Cross Section [\(cm^2\)]
     integer, parameter :: n = 1
         !+ Initial atomic energy level/state
     real(Float64), dimension(6), parameter :: A = [ 0.18450d0, -0.032226d0, &
@@ -1979,17 +1985,17 @@ function e_ioniz_1_janev(eb) result(sigma)
     real(Float64) :: Edn2
     real(Float64) :: e, x
     real(Float64) :: s
-  
+
     Edn2 = 13.6/real(n)**2
     e = eb * 1.d3 !keV to eV
-  
+
     x = (1.0 - Edn2/e)
     s = A(2)*x + A(3)*(x**2.0) + A(4)*(x**3.0) + A(5)*(x**4.0) + A(6)*(x**5.0)
     sigma = ((1.d-13)/(Edn2*e))*(A(1)*log(e/Edn2) + s)
     sigma = max(sigma,0.d0)
-  
+
 end function e_ioniz_1_janev
-  
+
 function e_ioniz_2_janev(eb) result(sigma)
     !+Calculates cross section for a electron-Hydrogen impact ionization from
     !+the \(n=2\) state at energy `eb`
@@ -2003,28 +2009,28 @@ function e_ioniz_2_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Collision energy [keV]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
+        !+ Cross Section [\(cm^2\)]
     integer, parameter :: n = 2
         !+ Initial atomic energy level/state
     real(Float64), dimension(6), parameter :: A = [ 0.14784d0, 0.0080871d0, &
-                                                   -0.062270d0, 1.9414d0,   & 
+                                                   -0.062270d0, 1.9414d0,   &
                                                    -2.1980d0, 0.95894d0 ]
         !+ Fitting parameters from Table 3 in Ref. 2
-        
+
     real(Float64) :: Edn2
     real(Float64) :: e, x
     real(Float64) :: s
-  
+
     Edn2 = 13.6/real(n)**2
     e = eb * 1.d3 !keV to eV
-  
+
     x = (1.0 - Edn2/e)
     s = A(2)*x + A(3)*(x**2.0) + A(4)*(x**3.0) + A(5)*(x**4.0) + A(6)*(x**5.0)
     sigma = ((1.d-13)/(Edn2*e))*(A(1)*log(e/Edn2) + s)
     sigma = max(sigma, 0.d0)
 
 end function e_ioniz_2_janev
-  
+
 function e_ioniz_3_janev(eb) result(sigma)
     !+Calculates cross section for a electron-Hydrogen impact ionization from
     !+the \(n=3\) state at energy `eb`
@@ -2038,21 +2044,21 @@ function e_ioniz_3_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Collision energy [keV]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
+        !+ Cross Section [\(cm^2\)]
     integer, parameter :: n = 3
         !+ Initial atomic energy level/state
     real(Float64), dimension(6), parameter :: A = [0.058463d0, -0.051272d0, &
                                                    0.85310d0, -0.57014d0,   &
                                                    0.76684d0, 0.00d0 ]
         !+ Fitting parameters from Table 3 in Ref. 2
-  
+
     real(Float64) :: Edn2
     real(Float64) :: e, x
     real(Float64) :: s
-  
+
     Edn2 = 13.6/real(n)**2
     e = eb * 1.d3 !keV to eV
-  
+
     if(e.ge.1.5) then
         x = (1.0 - Edn2/e)
         s = A(2)*x + A(3)*(x**2.0) + A(4)*(x**3.0) + A(5)*(x**4.0) + A(6)*(x**5.0)
@@ -2060,9 +2066,9 @@ function e_ioniz_3_janev(eb) result(sigma)
     else
         sigma = 0.d0
     endif
-  
+
 end function e_ioniz_3_janev
-  
+
 function e_ioniz_n(eb, n) result(sigma)
     !+Calculates cross section for a electron-Hydrogen impact ionization from
     !+the `n` state at energy `eb`
@@ -2079,8 +2085,8 @@ function e_ioniz_n(eb, n) result(sigma)
     integer, intent(in)       :: n
         !+ Initial atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64) :: rn, xn, Edn2
     real(Float64) :: g0, g1, g2, An, b, Bn
 
@@ -2114,9 +2120,9 @@ function e_ioniz_n(eb, n) result(sigma)
                 sigma = 0.d0
             endif
     end select
-  
+
 end function e_ioniz_n
-  
+
 function e_ioniz(eb, n_max) result(sigma)
     !+Calculates an array of cross sections for a electron-Hydrogen impact ionization from
     !+the \(n=1..n_{max}\) states at energy `eb`
@@ -2133,16 +2139,16 @@ function e_ioniz(eb, n_max) result(sigma)
     integer, intent(in)             :: n_max
         !+ Number of initial atomic energy levels/states to calculate
     real(Float64), dimension(n_max) :: sigma
-        !+ Array of cross sections where the n'th index refers to a ionization from the n'th state [\(cm^2\)] 
+        !+ Array of cross sections where the n'th index refers to a ionization from the n'th state [\(cm^2\)]
 
     integer :: i
-  
+
     do i=1,n_max
         sigma(i) = e_ioniz_n(eb,i)
     enddo
 
 end function e_ioniz
-  
+
 function e_excit_1_2_janev(eb) result(sigma)
     !+Calculates cross section for a electron-Hydrogen impact excitation transition from
     !+the \(n=1\) state to the \(m=2\) state at energy `eb`
@@ -2156,8 +2162,8 @@ function e_excit_1_2_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Collision energy [keV]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: sigma0=5.984d0
     real(Float64), parameter :: deltaE=10.2d0
     real(Float64), parameter :: a=0.228d0
@@ -2170,9 +2176,9 @@ function e_excit_1_2_janev(eb) result(sigma)
                                                     -20.877d0, 49.735d0, &
                                                     -46.249d0, 17.442d0 ]
         !+ Fitting parameters from Table 2 in Ref. 2
-  
+
     real(Float64) :: ecoll, x, s
-  
+
     ecoll = eb*1.d3
     x = (ecoll)/deltaE
 
@@ -2180,25 +2186,25 @@ function e_excit_1_2_janev(eb) result(sigma)
         sigma = 1.d-16 * (a + b*(ecoll - deltaE))
         return
     endif
-  
+
     if((ecoll.ge.11.56).and.(ecoll.le.12.23)) then
         sigma = 1.d-16 * c
         return
     endif
-  
+
     if(ecoll.ge.12.23) then
         s = An(2) + An(3)/x + An(4)/x**2.0 + An(5)/x**3.0 + An(6)/x**4.0
         sigma = 1.d-16 * sigma0/(deltaE*x) * (An(1)*log(x) + s)
         return
     endif
-  
+
     if(x.le.1.0) then
         sigma = 0.0
         return
     endif
 
 end function e_excit_1_2_janev
-  
+
 function e_excit_1_3_janev(eb) result(sigma)
     !+Calculates cross section for a electron-Hydrogen impact excitation transition from
     !+the \(n=1\) state to the \(m=3\) state at energy `eb`
@@ -2212,30 +2218,30 @@ function e_excit_1_3_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Collision energy [keV]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: sigma0 = 5.984d0
     real(Float64), parameter :: deltaE = 12.09d0
         !+ Fitting parameter from Table 2 in Ref. 2
     real(Float64), parameter :: alpha = 0.38277d0
         !+ Fitting parameter from Table 2 in Ref. 2
     real(Float64), dimension(5), parameter :: A = [ 0.75448d0, 0.42956d0, &
-                                                   -0.58288d0, 1.0693d0,  &  
-                                                    0.d0 ]     
+                                                   -0.58288d0, 1.0693d0,  &
+                                                    0.d0 ]
         !+ Fitting parameters from Table 2 in Ref. 2
 
     real(Float64) :: ecoll, x, s
-  
+
     ecoll = eb*1.d3
     x=ecoll/deltaE
     s = A(2) + A(3)/x + A(4)/x**2.0 + A(5)/x**3.0
-    
+
     sigma = 1.d-16 * sigma0/(deltaE*x) * (1.0 - 1.0/x)**alpha * (A(1)*log(x) + s)
-  
+
     if(x.le.1.0) sigma = 0.d0
-  
+
 end function e_excit_1_3_janev
-  
+
 function e_excit_1_4_janev(eb) result(sigma)
     !+Calculates cross section for a electron-Hydrogen impact excitation transition from
     !+the \(n=1\) state to the \(m=4\) state at energy `eb`
@@ -2249,8 +2255,8 @@ function e_excit_1_4_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Collision energy [keV]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: sigma0 = 5.984d0
     real(Float64), parameter :: deltaE = 12.75d0
         !+ Fitting parameter from Table 2 in Ref. 2
@@ -2260,19 +2266,19 @@ function e_excit_1_4_janev(eb) result(sigma)
                                                     0.19701d0, 0.d0,      &
                                                     0.d0 ]
         !+ Fitting parameters from Table 2 in Ref. 2
-  
+
     real(Float64) :: ecoll, x, s
-  
+
     ecoll = eb*1.d3
     x=ecoll/deltaE
     s = A(2) + A(3)/x + A(4)/x**2.0 + A(5)/x**3.0
-    
+
     sigma = 1.d-16 * sigma0/(deltaE*x) * (1.0 - 1.0/x)**alpha * (A(1)*log(x) + s)
-  
+
     if(x.le.1.0) sigma = 0.d0
-  
+
 end function e_excit_1_4_janev
-  
+
 function e_excit_1_5_janev(eb) result(sigma)
     !+Calculates cross section for a electron-Hydrogen impact excitation transition from
     !+the \(n=1\) state to the \(m=5\) state at energy `eb`
@@ -2286,8 +2292,8 @@ function e_excit_1_5_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Collision energy [keV]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: sigma0 = 5.984d0
     real(Float64), parameter :: deltaE = 13.06d0
         !+ Fitting parameter from Table 2 in Ref. 2
@@ -2295,21 +2301,21 @@ function e_excit_1_5_janev(eb) result(sigma)
         !+ Fitting parameter from Table 2 in Ref. 2
     real(Float64), dimension(5), parameter :: A = [ 0.11508d0, 0.13092d0, &
                                                     0.23581d0, 0.d0,      &
-                                                    0.d0 ]   
+                                                    0.d0 ]
         !+ Fitting parameters from Table 2 in Ref. 2
-  
+
     real(Float64) :: ecoll, x, s
-  
+
     ecoll = eb*1.d3
     x=ecoll/deltaE
     s = A(2) + A(3)/x + A(4)/x**2.0 + A(5)/x**3.0
-    
+
     sigma = 1.d-16 * sigma0/(deltaE*x) * (1.0 - 1.0/x)**alpha * (A(1)*log(x) + s)
-  
+
     if(x.le.1.0) sigma = 0.d0
-  
+
 end function e_excit_1_5_janev
-  
+
 function e_excit_f(n, m) result(fnm)
     !+ Oscillator strength for a `n`\(\rightarrow\)`m` transition due to electron-Hydrogen impact excitation
     !+
@@ -2321,14 +2327,14 @@ function e_excit_f(n, m) result(fnm)
         !+ Final atomic energy level/state
     real(Float64)       :: fnm
         !+ Oscillator strength
-  
+
     real(Float64), dimension(3) :: g
     real(Float64) :: x, nf, mf, gs
-  
+
     nf = real(n)
     mf = real(m)
     x = 1.0 - (nf/mf)**2.0
-  
+
     select case (n)
         case (1)
             g = [1.133,-0.4059,0.0714]
@@ -2338,13 +2344,13 @@ function e_excit_f(n, m) result(fnm)
             g(1) = 0.9935 + 0.2328/nf - 0.1296/nf**2
             g(2) =-1.0/nf * (0.6282 - 0.5598/nf + 0.5299/nf**2)
             g(3) = 1.0/nf**2.0 * (0.3887 - 1.1810/nf + 1.4700/nf**2)
-    end select 
+    end select
 
     gs = g(1) + g(2)/x + g(3)/x**2
     fnm = 32.0/(3.0*sqrt(3.0)*PI) * nf/mf**3 * 1/x**3 * gs
 
 end function e_excit_f
-  
+
 function e_excit_1_janev(eb, m_max) result(sigma)
     !+Calculates an array of cross sections for a electron-Hydrogen impact excitation transition from
     !+the \(n=1\) state to the \(m=1..m_{max}\) state at energy `eb`
@@ -2362,12 +2368,12 @@ function e_excit_1_janev(eb, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refers to
-        !+an excitation from the \(n=1\) state to the m'th state [\(cm^2\)] 
-  
+        !+an excitation from the \(n=1\) state to the m'th state [\(cm^2\)]
+
     integer :: m
     real(Float64) :: x, y, A, B, deltaE
-  
-    do m=1,m_max 
+
+    do m=1,m_max
         select case (m)
             case (1)
                 sigma(1) = 0.d0
@@ -2394,9 +2400,9 @@ function e_excit_1_janev(eb, m_max) result(sigma)
                 if(x.le.1.0) sigma(m) = 0.d0
         end select
     enddo
-  
+
 end function e_excit_1_janev
-  
+
 function e_excit_2_3_janev(eb) result(sigma)
     !+Calculates cross section for a electron-Hydrogen impact excitation transition from
     !+the \(n=2\) state to the \(m=3\) state at energy `eb`
@@ -2411,30 +2417,30 @@ function e_excit_2_3_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Collision energy [keV]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: sigma0 = 5.984d0
     real(Float64), parameter :: deltaE = 1.8888d0
-        !+ Energy difference between \(n=1\) and \(n=3\): 
-        !+ \(\Delta E = 13.6\left (\frac{1}{2^2} - \frac{1}{3^2}\right )\) 
+        !+ Energy difference between \(n=1\) and \(n=3\):
+        !+ \(\Delta E = 13.6\left (\frac{1}{2^2} - \frac{1}{3^2}\right )\)
     real(Float64), parameter :: alpha = 1.3196d0
         !+ Fitting parameter from Section 2.1.1 B in Ref. 2
     real(Float64), dimension(5), parameter :: A = [ 38.906d0, 5.2373d0, 119.25d0, &
                                                    -595.39d0, 816.71d0]
         !+ Fitting parameters from Section 2.1.1 B in Ref. 2
-  
+
     real(Float64) :: ecoll, x, s
-  
+
     ecoll = eb*1.d3
     x = ecoll/deltaE
     s = A(2) + A(3)/x + A(4)/x**2.0 + A(5)/x**3.0
-    
+
     sigma = 1.d-16 * sigma0/(deltaE*x) * (1.0 - 1.0/x)**alpha * (A(1)*log(x) + s)
-  
+
     if(x.le.1.0) sigma = 0.d0
-  
+
 end function e_excit_2_3_janev
-  
+
 function e_excit_n(eb, n, m_max) result(sigma)
     !+Calculates an array of cross sections for a electron-Hydrogen impact excitation transition from
     !+the `n` state to the \(m=1..m_{max}\) state at energy `eb`
@@ -2455,14 +2461,14 @@ function e_excit_n(eb, n, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refers to
-        !+an excitation from the `n`\(\rightarrow\)`m` state [\(cm^2\)] 
-  
+        !+an excitation from the `n`\(\rightarrow\)`m` state [\(cm^2\)]
+
     integer :: m
     real(Float64) :: nf, mf
     real(Float64) :: x, y, A, B, bn, r, deltaE
-  
+
     nf = real(n)
-  
+
     if(n.eq.1) then
         sigma = e_excit_1_janev(eb, m_max)
     else
@@ -2482,7 +2488,7 @@ function e_excit_n(eb, n, m_max) result(sigma)
 
                 A = 2.0 * nf**2 * e_excit_f(n,m)/y
                 bn = 1.0/nf*(4.0 - 18.63/nf + 36.24/nf**2 - 28.09/nf**3)
-                B = 4.0 * nf**4/(mf**3*y**2)*(1.0 + 4.0/(3.0*y) + bn/y**2.0)     
+                B = 4.0 * nf**4/(mf**3*y**2)*(1.0 + 4.0/(3.0*y) + bn/y**2.0)
 
                 sigma(m) = 1.76e-16*nf**2/(y*x)*(1.0 - exp(-r*y*x))* &
                            (A*(log(x) + 1.0/(2.0*x)) + (B - A*log(2.0*n**2.0/y))* &
@@ -2492,9 +2498,9 @@ function e_excit_n(eb, n, m_max) result(sigma)
             endif
         enddo m_loop
     endif
-        
+
 end function e_excit_n
-  
+
 function e_excit_n_m(eb, n, m) result(sigma)
     !+Calculates an array of cross sections for a electron-Hydrogen impact excitation transition from
     !+the `n` \(\rightarrow\) `m` state at energy `eb`
@@ -2514,19 +2520,19 @@ function e_excit_n_m(eb, n, m) result(sigma)
     integer, intent(in)       :: m
         !+ Final atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(12) :: sigma_m
-  
+
     sigma_m = e_excit_n(eb, n, 12)
     if(m.le.0) then
         sigma = sum(sigma_m)
     else
         sigma = sigma_m(m)
     endif
-  
+
 end function e_excit_n_m
-  
+
 function e_excit(eb, n_max, m_max) result(sigma)
     !+Calculates a matrix of cross section for a proton-Hydrogen impact excitation transition
     !+from the \(n=1..n_{max} \rightarrow m=1..m_{max}\) states at energy `eb`
@@ -2547,24 +2553,24 @@ function e_excit(eb, n_max, m_max) result(sigma)
         !+ Number of final atomic energy levels/states
     real(Float64), dimension(n_max,m_max) :: sigma
         !+ Matrix of cross sections where the subscripts correspond
-        !+ to the \(n \rightarrow m\) transitions: e_excit[n,m] [\(cm^2\)] 
-  
+        !+ to the \(n \rightarrow m\) transitions: e_excit[n,m] [\(cm^2\)]
+
     real(Float64), dimension(12,12) :: sigma_full
-  
+
     integer :: n
-  
+
     do n=1,12
         sigma_full(n,:) = e_excit_n(eb, n, 12)
     enddo
-  
+
     sigma = sigma_full(1:n_max,1:m_max)
-  
+
 end function e_excit
 
 !Impurities
 !A[q]_cx_[n]_[source]
 function B5_cx_1_adas(eb) result(sigma)
-    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom
     !+in the \(n=1\) state colliding with a fully stripped Boron ion at energy `eb`
     !+
     !+###Equation
@@ -2575,17 +2581,17 @@ function B5_cx_1_adas(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(7), parameter :: A = [ 1.174052518d3, -1.793561728d3, &
                                                     1.117522436d3, -3.679435571d2, &
                                                     6.750816878d1, -6.542029074d0, &
                                                     2.614113716d-1 ]
     real(Float64) :: e, l, p
-  
+
     e = max(eb*1.d3,10.0)
     l = log10(e)
-  
+
     if(e.le.4.d5) then
         p = A(1) + A(2)*l + A(3)*l**2 + A(4)*l**3 + &
             A(5)*l**4 + A(6)*l**5 + A(7)*l**6
@@ -2593,11 +2599,11 @@ function B5_cx_1_adas(eb) result(sigma)
     else
         sigma = 0.d0
     endif
-  
+
 end function B5_cx_1_adas
-  
+
 function B5_cx_2_adas(eb) result(sigma)
-    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom
     !+in the \(n=2\) state colliding with a fully stripped Boron ion at energy `eb`
     !+
     !+###Equation
@@ -2608,18 +2614,18 @@ function B5_cx_2_adas(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(10), parameter :: A = [6.603246818d1, -3.072575676d2, &
                                                     5.030801019d2, -4.585636345d2, &
                                                     2.568666393d2, -9.185150382d1, &
                                                     2.100012584d1, -2.964174788d0, &
                                                     2.346396110d-1, -7.943766873d-3]
     real(Float64) :: e, l, p
-  
+
     e = max(eb*1.d3,10.0)
     l = log10(e)
-  
+
     if(e.le.1.d5) then
         p = A(1) + A(2)*l + A(3)*l**2 + A(4)*l**3 + &
             A(5)*l**4 + A(6)*l**5 + A(7)*l**6 +     &
@@ -2628,11 +2634,11 @@ function B5_cx_2_adas(eb) result(sigma)
     else
         sigma = 0.d0
     endif
-  
+
 end function B5_cx_2_adas
-  
+
 function C6_cx_1_adas(eb) result(sigma)
-    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom
     !+in the \(n=1\) state colliding with a fully stripped Carbon ion at energy `eb`
     !+
     !+###Equation
@@ -2643,26 +2649,26 @@ function C6_cx_1_adas(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(7), parameter :: A = [2.007882674d2, -3.546893286d2, &
                                                    2.381542403d2, -8.355431742d1, &
                                                    1.617519888d1, -1.638152470d0, &
                                                    6.768953863d-2 ]
-  
+
     real(Float64) :: e, l, p
-  
+
     e = max(eb*1.d3,1.5d3)
     l = log10(e)
-  
+
     p = A(1) + A(2)*l + A(3)*l**2 + A(4)*l**3 + &
         A(5)*l**4 + A(6)*l**5 + A(7)*l**6
     sigma = 10.d0**p
-  
+
 end function C6_cx_1_adas
-  
+
 function C6_cx_2_adas(eb) result(sigma)
-    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom
     !+in the \(n=2\) state colliding with a fully stripped Carbon ion at energy `eb`
     !+
     !+###Equation
@@ -2673,8 +2679,8 @@ function C6_cx_2_adas(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(11), parameter :: A = [9.151879441d5, -2.134573133d6, &
                                                     2.223792624d6, -1.362648703d6, &
                                                     5.438401343d5, -1.477110500d5, &
@@ -2682,19 +2688,19 @@ function C6_cx_2_adas(eb) result(sigma)
                                                     2.921934171d2, -1.425552507d1, &
                                                     3.106007048d-1 ]
     real(Float64) :: e, l, p
-  
+
     e = max(eb*1.d3,1.5d3)*2.0**2
     l = log10(e)
-  
+
     p = A(1) + A(2)*l + A(3)*l**2 + A(4)*l**3 + &
         A(5)*l**4 + A(6)*l**5 + A(7)*l**6 +     &
         A(8)*l**7 + A(9)*l**8 + A(10)*l**9 + A(11)*l**10
     sigma = 10.d0**p
-  
+
 end function C6_cx_2_adas
-  
+
 function C6_cx_3_adas(eb) result(sigma)
-    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom
     !+in the \(n=3\) state colliding with a fully stripped Carbon ion at energy `eb`
     !+
     !+###Equation
@@ -2705,28 +2711,28 @@ function C6_cx_3_adas(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(11), parameter :: A = [9.208877916d5, -2.147294379d6, &
                                                     2.236451628d6, -1.370042347d6, &
                                                     5.466461899d5, -1.484338816d5, &
                                                     2.777765778d4, -3.537459450d3, &
                                                     2.933884362d2, -1.430994136d1, &
-                                                    3.117002878d-1 ] 
+                                                    3.117002878d-1 ]
     real(Float64) :: e, l, p
-  
+
     e = max(eb*1.d3,1.5d3)*3.0**2
     l = log10(e)
-  
+
     p = A(1) + A(2)*l + A(3)*l**2 + A(4)*l**3 + &
         A(5)*l**4 + A(6)*l**5 + A(7)*l**6 +     &
         A(8)*l**7 + A(9)*l**8 + A(10)*l**9 + A(11)*l**10
     sigma = 10.d0**p
-  
+
 end function C6_cx_3_adas
-  
+
 function Aq_cx_n_adas(eb, q, n) result(sigma)
-    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom
     !+in the `n` state colliding with a ion with charge `q` at energy `eb`
     !+
     !+@note Returns 0 if ADAS cross sections are not available for given inputs
@@ -2743,8 +2749,8 @@ function Aq_cx_n_adas(eb, q, n) result(sigma)
     integer, intent(in)       :: n
         !+ Initial atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     sigma = 0.d0
     select case (q)
         case (5)
@@ -2756,12 +2762,12 @@ function Aq_cx_n_adas(eb, q, n) result(sigma)
             if(n.eq.3) sigma = C6_cx_3_adas(eb)
         case DEFAULT
             sigma = 0.d0
-    end select  
-      
+    end select
+
 end function Aq_cx_n_adas
-  
+
 function B5_cx_1_janev(eb) result(sigma)
-    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom
     !+in the \(n=1\) state colliding with a fully stripped Boron ion at energy `eb`
     !+
     !+###Equation
@@ -2772,23 +2778,23 @@ function B5_cx_1_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(11), parameter :: A = [31.226d0, 1.1442d0,    &
                                                     4.8372d-8, 3.0961d-10, &
                                                     4.7205d0, 6.2844d-7,   &
                                                     3.1297d0, 0.12556d0,   &
                                                     0.30098d0, 5.9607d-2,  &
                                                    -0.57923d0 ]
-  
+
     sigma = 1.d-16*A(1)*(exp(-A(2)/eb**A(8)) /  &
            (1.0 + A(3)*eb**2 + A(4)*eb**A(5) +  &
             A(6)*eb**A(7)) + A(9)*exp(-A(10)*eb) /eb**A(11))
-  
-end function B5_cx_1_janev 
-  
+
+end function B5_cx_1_janev
+
 function C6_cx_1_janev(eb) result(sigma)
-    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom
     !+in the \(n=1\) state colliding with a fully stripped Carbon ion at energy `eb`
     !+
     !+###Equation
@@ -2799,23 +2805,23 @@ function C6_cx_1_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(11), parameter :: A = [418.18d0, 2.1585d0,   &
                                                     3.4808d-4, 5.3333d-9, &
                                                     4.6556d0, 0.33755d0,  &
                                                     0.81736d0, 0.27874d0, &
                                                     1.8003d-6, 7.1033d-2, &
                                                     0.53261d0 ]
-  
+
     sigma = 1.d-16*A(1)*(exp(-A(2)/eb**A(8)) /  &
            (1.0 + A(3)*eb**2 + A(4)*eb**A(5) +  &
             A(6)*eb**A(7)) + A(9)*exp(-A(10)*eb) /eb**A(11))
-  
-end function C6_cx_1_janev 
-  
+
+end function C6_cx_1_janev
+
 function Aq_cx_n_janev(eb, q, n) result(sigma)
-    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom
     !+in the `n` state colliding with a ion with charge `q` at energy `eb`
     !+
     !+###Equation
@@ -2832,16 +2838,16 @@ function Aq_cx_n_janev(eb, q, n) result(sigma)
     integer, intent(in)       :: n
         !+ Initial atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 1.507d5
     real(Float64), parameter :: B = 1.974d-5
-  
+
     real(Float64) :: etil, nf, qf
-  
+
     nf = real(n)
     qf = real(q)
-  
+
     if((n.eq.1).and.(q.eq.5)) then
         sigma = B5_cx_1_janev(eb)
         return
@@ -2856,16 +2862,16 @@ function Aq_cx_n_janev(eb, q, n) result(sigma)
         sigma = 0.d0
         return
     endif
-  
+
     etil = eb*(nf**2.0)/(qf**0.5)
-  
+
     sigma = qf*nf**4 * 7.04d-16 * A/(etil**3.5 * (1.0 + B*etil**2)) * &
             (1.0 - exp(-2.0*etil**3.5 * (1.0 + B*etil**2)/(3.0*A)))
-  
+
 end function Aq_cx_n_janev
-  
+
 function Aq_cx_n(eb, q, n) result(sigma)
-    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total charge exchange cross section for a Neutral Hydrogen atom
     !+in the `n` state colliding with a ion with charge `q` at energy `eb`
     !+
     !+@note Uses ADAS(Ref. 4) cross sections if available else uses Janev (Ref. 5) cross sections
@@ -2885,17 +2891,17 @@ function Aq_cx_n(eb, q, n) result(sigma)
     integer, intent(in)       :: n
         !+ Initial atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     sigma = Aq_cx_n_adas(eb, q, n)
     if(sigma.eq.0.d0) then
         sigma = Aq_cx_n_janev(eb, q, n)
     endif
-  
+
 end function Aq_cx_n
-  
+
 function Aq_cx(eb, q, n_max) result(sigma)
-    !+ Calculates an array of total charge exchange cross sections for a Neutral Hydrogen atom 
+    !+ Calculates an array of total charge exchange cross sections for a Neutral Hydrogen atom
     !+in the n=1...n_max states colliding with a ion with charge `q` at energy `eb`
     !+
     !+@note Uses ADAS(Ref. 4) cross sections if available else uses Janev (Ref. 5) cross sections
@@ -2913,19 +2919,19 @@ function Aq_cx(eb, q, n_max) result(sigma)
     integer, intent(in)             :: n_max
         !+ Number of initial atomic energy levels/states
     real(Float64), dimension(n_max) :: sigma
-        !+ Array of cross sections where the n'th index refers to a charge exchange from the n'th state [\(cm^2\)] 
-  
+        !+ Array of cross sections where the n'th index refers to a charge exchange from the n'th state [\(cm^2\)]
+
     integer :: n
-  
+
     do n=1,n_max
         sigma(n) = Aq_cx_n(eb, q, n)
     enddo
-  
+
 end function Aq_cx
-  
+
 !Impurity impact ionization
 function B5_ioniz_1_janev(eb) result(sigma)
-    !+ Calculates the total ionization cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total ionization cross section for a Neutral Hydrogen atom
     !+in the \(n=1\) state colliding with a fully stripped Boron ion at energy `eb`
     !+
     !+###Equation
@@ -2936,20 +2942,20 @@ function B5_ioniz_1_janev(eb) result(sigma)
     real(Float64), intent(in) :: eb
         !+ Relative collision energy [keV/amu]
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(8), parameter :: A = [351.52d0, 233.63d0,   &
                                                    3.2952d3, 5.3787d-6,  &
                                                    1.8834d-2, -2.2064d0, &
                                                    7.2074d0, -3.78664d0 ]
-  
+
     sigma = 1.d-16*A(1)*(exp(-A(2)/eb)*log(1 + A(3)*eb)/eb &
           + A(4)*exp(-A(5)*eb)/((eb**A(6)) + A(7)*(eb**A(8))))
-  
+
 end function B5_ioniz_1_janev
-  
+
 function C6_ioniz_1_janev(eb) result(sigma)
-    !+ Calculates the total ionization cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total ionization cross section for a Neutral Hydrogen atom
     !+in the \(n=1\) state colliding with a fully stripped Carbon ion at energy `eb`
     !+
     !+###Equation
@@ -2959,19 +2965,19 @@ function C6_ioniz_1_janev(eb) result(sigma)
     !+* Page 154 in Ref. 5 [[atomic_tables(module)]]
     real(Float64), intent(in) :: eb
     real(Float64)             :: sigma
-  
+
     real(Float64), dimension(8), parameter :: A = [ 438.36d0, 327.10d0,    &
                                                     1.4444d5, 3.5212d-3,   &
                                                     8.3031d-3, -0.63731d0, &
                                                     1.9116d4, -3.1003d0 ]
-  
+
     sigma = 1.d-16*A(1)*(exp(-A(2)/eb)*log(1 + A(3)*eb)/eb &
           + A(4)*exp(-A(5)*eb)/((eb**A(6)) + A(7)*(eb**A(8))))
-  
+
 end function C6_ioniz_1_janev
-  
+
 function Aq_ioniz_n_janev(eb, q, n) result(sigma)
-    !+ Calculates the generic total ionization cross section for a Neutral Hydrogen atom 
+    !+ Calculates the generic total ionization cross section for a Neutral Hydrogen atom
     !+in the `n` state colliding with a ion with charge `q` at energy `eb`
     !+
     !+###Equation
@@ -2986,31 +2992,31 @@ function Aq_ioniz_n_janev(eb, q, n) result(sigma)
     integer, intent(in)       :: n
         !+ Initial atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: M = 0.283d0
     real(Float64), parameter :: B = 4.04d0
     real(Float64), parameter :: c = 137.d0
     real(Float64), parameter :: g = 0.662d0
     real(Float64), parameter :: lambda = 0.76d0
-  
+
     real(Float64) :: nf, qf, u, v, sigma_b
-  
+
     nf = real(n)
     qf = real(q)
     v = sqrt(eb/25.)
     u = nf*v
-  
+
     sigma_b = 3.52d-16 * (nf**4) * (qf**2)/(u**2) * &
               (M * (log((u**2)/(c**2 - u**2)) - (u**2)/(c**2)) + B - g/u**2)
     sigma_b = max(sigma_b,0.d0)
-  
+
     sigma = exp(-lambda*qf/u**2)*sigma_b
-  
+
 end function Aq_ioniz_n_janev
-  
+
 function Aq_ioniz_n(eb, q, n) result(sigma)
-    !+ Calculates the total ionization cross section for a Neutral Hydrogen atom 
+    !+ Calculates the total ionization cross section for a Neutral Hydrogen atom
     !+in the `n` state colliding with a ion with charge `q` at energy `eb`
     !+
     !+@note Uses specialized cross sections if available else uses generic cross sections
@@ -3029,24 +3035,24 @@ function Aq_ioniz_n(eb, q, n) result(sigma)
     integer, intent(in)       :: n
         !+ Initial atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     if((q.eq.5).and.(n.eq.1)) then
         sigma = B5_ioniz_1_janev(eb)
         return
     endif
-  
+
     if((q.eq.6).and.(n.eq.1)) then
         sigma = C6_ioniz_1_janev(eb)
         return
     endif
-  
+
     sigma = Aq_ioniz_n_janev(eb, q, n)
-  
+
 end function Aq_ioniz_n
-  
+
 function Aq_ioniz(eb, q, n_max) result(sigma)
-    !+ Calculates an array of total ionization cross sections for a Neutral Hydrogen atom 
+    !+ Calculates an array of total ionization cross sections for a Neutral Hydrogen atom
     !+in the n=1...n_max states colliding with a ion with charge `q` at energy `eb`
     !+
     !+@note Uses specialized cross sections if available else uses generic cross sections
@@ -3065,16 +3071,16 @@ function Aq_ioniz(eb, q, n_max) result(sigma)
     integer, intent(in)             :: n_max
         !+ Number of initial states n to calculate
     real(Float64), dimension(n_max) :: sigma
-        !+ Array of cross sections where the n'th index refers to a ionization from the n'th state [\(cm^2\)] 
-        
+        !+ Array of cross sections where the n'th index refers to a ionization from the n'th state [\(cm^2\)]
+
     integer :: n
-  
+
     do n=1,n_max
         sigma(n) = Aq_ioniz_n(eb, q, n)
     enddo
-  
+
 end function Aq_ioniz
-  
+
 !Impurity impact excitation
 function Aq_excit_1_2_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
@@ -3091,21 +3097,21 @@ function Aq_excit_1_2_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(6), parameter :: A = [38.738d0, 37.033d0,   &
                                                    0.39862d0, 7.7582d-5, &
                                                    0.25402d0, -2.7418d0 ]
     real(Float64) :: Etil, xsi, qf
-  
+
     qf = real(q)
     etil = eb/qf
     xsi = 2.**(0.5238*(1 - sqrt(2.0/qf)))
     sigma = qf*1.d-16*xsi*A(1)*(exp(-A(2)/etil)*log(1 + A(3)*etil)/etil &
           + A(4)*exp(-A(5)*etil)/etil**A(6))
-  
+
 end function Aq_excit_1_2_janev
-  
+
 function Aq_excit_1_3_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=1\) state to the \(m=3\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3121,21 +3127,21 @@ function Aq_excit_1_3_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(6), parameter :: A = [4.3619d0, 57.451d0,  &
                                                    21.001d0, 2.3292d-4, &
                                                    0.083130d0, -2.2364d0 ]
     real(Float64) :: Etil, xsi, qf
-  
+
     qf = real(q)
     etil = eb/qf
     xsi = 2.**(0.5238*(1 - sqrt(2.0/qf)))
     sigma = qf*1.d-16*xsi*A(1)*(exp(-A(2)/etil)*log(1 + A(3)*etil)/etil &
           + A(4)*exp(-A(5)*etil)/etil**A(6))
-  
+
 end function Aq_excit_1_3_janev
-  
+
 function Aq_excit_1_4_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=1\) state to the \(m=4\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3151,21 +3157,21 @@ function Aq_excit_1_4_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(6), parameter :: A = [1.3730d0, 60.710d0,  &
                                                    31.797d0, 2.0207d-4, &
                                                    0.082513d0, -2.3055d0 ]
     real(Float64) :: Etil, xsi, qf
-  
+
     qf = real(q)
     etil = eb/qf
     xsi = 2.**(0.5238*(1 - sqrt(2.0/qf)))
     sigma = qf*1.d-16*xsi*A(1)*(exp(-A(2)/etil)*log(1 + A(3)*etil)/etil &
           + A(4)*exp(-A(5)*etil)/etil**A(6))
-  
+
 end function Aq_excit_1_4_janev
-  
+
 function Aq_excit_1_5_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=1\) state to the \(m=5\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3181,21 +3187,21 @@ function Aq_excit_1_5_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(6), parameter :: A = [0.56565d0, 67.333d0, &
                                                    55.290d0, 2.1595d-4, &
                                                    0.081624d0, -2.1971d0 ]
     real(Float64) :: Etil, xsi, qf
-  
+
     qf = real(q)
     etil = eb/qf
     xsi = 2.**(0.5238*(1 - sqrt(2.0/qf)))
     sigma = qf*1.d-16*xsi*A(1)*(exp(-A(2)/etil)*log(1 + A(3)*etil)/etil &
           + A(4)*exp(-A(5)*etil)/etil**A(6))
-  
+
 end function Aq_excit_1_5_janev
-  
+
 function Aq_excit_1_janev(eb, q, m_max) result(sigma)
     !+Calculates an array of the excitation cross sections for a neutral Hydrogen atom transitioning from
     !+the \(n=1\) state to the m=1..`m_max` states due to a collision an ion with charge `q` at energy `eb`
@@ -3216,10 +3222,10 @@ function Aq_excit_1_janev(eb, q, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refers to
-        !+an excitation from the \(n=1\) state to the m'th state [\(cm^2\)] 
-  
+        !+an excitation from the \(n=1\) state to the m'th state [\(cm^2\)]
+
     integer :: m
-  
+
     sigma = 0.d0
     do m=1,m_max
         select case (m)
@@ -3237,9 +3243,9 @@ function Aq_excit_1_janev(eb, q, m_max) result(sigma)
                 sigma(m) = sigma(5)*(5.0/m)**3.0
         end select
     enddo
-  
+
 end function Aq_excit_1_janev
-  
+
 function Aq_excit_2_3_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=2\) state to the \(m=3\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3255,21 +3261,21 @@ function Aq_excit_2_3_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(6), parameter :: A = [358.03d0, 25.283d0,   &
                                                    1.4726d0, 0.014398d0, &
                                                    0.12207d0, -0.86210d0 ]
     real(Float64) :: etil, qf, xsi
-  
-    qf = real(q) 
+
+    qf = real(q)
     etil = eb/qf
     xsi = 2.0**(0.5238*(1 - sqrt(2.0/qf)))
     sigma = qf*1.e-16*xsi*A(1)*(exp(-A(2)/etil)*log(1 + A(3)*etil)/etil &
           + A(4)*exp(-A(5)*etil)/etil**A(6))
-  
+
 end function Aq_excit_2_3_janev
-  
+
 function Aq_excit_2_4_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=2\) state to the \(m=4\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3285,21 +3291,21 @@ function Aq_excit_2_4_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(6), parameter :: A = [50.744d0, 19.416d0,   &
                                                    4.0262d0, 0.014398d0, &
                                                    0.31584d0, -1.4799d0 ]
     real(Float64) :: etil, qf, xsi
-  
-    qf = real(q) 
+
+    qf = real(q)
     etil = eb/qf
     xsi = 2.0**(0.5238*(1 - sqrt(2.0/qf)))
     sigma = qf*1.e-16*xsi*A(1)*(exp(-A(2)/etil)*log(1 + A(3)*etil)/etil &
           + A(4)*exp(-A(5)*etil)/etil**A(6))
-  
+
 end function Aq_excit_2_4_janev
-  
+
 function Aq_excit_2_5_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=2\) state to the \(m=5\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3315,21 +3321,21 @@ function Aq_excit_2_5_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(6), parameter :: A = [18.264d0, 18.973d0,   &
                                                    2.9056d0, 0.013701d0, &
                                                    0.31711d0, -1.4775d0 ]
     real(Float64) :: etil, qf, xsi
-  
-    qf = real(q) 
+
+    qf = real(q)
     etil = eb/qf
     xsi = 2.0**(0.5238*(1 - sqrt(2.0/qf)))
     sigma = qf*1.e-16*xsi*A(1)*(exp(-A(2)/etil)*log(1 + A(3)*etil)/etil &
           + A(4)*exp(-A(5)*etil)/etil**A(6))
-  
+
 end function Aq_excit_2_5_janev
-  
+
 function Aq_excit_2_6_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=2\) state to the \(m=6\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3345,18 +3351,18 @@ function Aq_excit_2_6_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 0.4610d0
-  
+
     real(Float64) :: hi
-  
+
     hi = 2.0**(0.397*(1.0 - sqrt(2.0/q)))
-  
+
     sigma = A*hi*Aq_excit_2_5_janev(eb, q)
 
 end function Aq_excit_2_6_janev
-  
+
 function Aq_excit_2_7_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=2\) state to the \(m=7\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3372,18 +3378,18 @@ function Aq_excit_2_7_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 0.2475d0
-  
+
     real(Float64) :: hi
-  
+
     hi = 2.0**(0.397*(1.0 - sqrt(2.0/q)))
-  
+
     sigma = A*hi*Aq_excit_2_5_janev(eb, q)
-  
+
 end function Aq_excit_2_7_janev
-  
+
 function Aq_excit_2_8_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=2\) state to the \(m=8\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3399,18 +3405,18 @@ function Aq_excit_2_8_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 0.1465d0
-  
+
     real(Float64) :: hi
-  
+
     hi = 2.0**(0.397*(1.0 - sqrt(2.0/q)))
-  
+
     sigma = A*hi*Aq_excit_2_5_janev(eb, q)
-  
+
 end function Aq_excit_2_8_janev
-  
+
 function Aq_excit_2_9_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=2\) state to the \(m=9\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3426,18 +3432,18 @@ function Aq_excit_2_9_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 0.092d0
-  
+
     real(Float64) :: hi
-  
+
     hi = 2.0**(0.397*(1.0 - sqrt(2.0/q)))
-  
+
     sigma = A*hi*Aq_excit_2_5_janev(eb, q)
-  
+
 end function Aq_excit_2_9_janev
-  
+
 function Aq_excit_2_10_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=2\) state to the \(m=10\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3453,18 +3459,18 @@ function Aq_excit_2_10_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 0.0605d0
-  
+
     real(Float64) :: hi
-  
+
     hi = 2.0**(0.397*(1.0 - sqrt(2.0/q)))
-  
+
     sigma = A*hi*Aq_excit_2_5_janev(eb, q)
-  
+
 end function Aq_excit_2_10_janev
-  
+
 function Aq_excit_2_janev(eb, q, m_max) result(sigma)
     !+Calculates an array of the excitation cross sections for a neutral Hydrogen atom transitioning from
     !+the \(n=2\) state to the m=1..`m_max` states due to a collision an ion with charge `q` at energy `eb`
@@ -3484,10 +3490,10 @@ function Aq_excit_2_janev(eb, q, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refers to
-        !+an excitation from the \(n=2\) state to the m'th state [\(cm^2\)] 
-  
+        !+an excitation from the \(n=2\) state to the m'th state [\(cm^2\)]
+
     integer :: m
-  
+
     sigma = 0.d0
     do m=1,m_max
         select case (m)
@@ -3515,9 +3521,9 @@ function Aq_excit_2_janev(eb, q, m_max) result(sigma)
                 sigma(m) = sigma(10)*(10.0/m)**3.0
         end select
     enddo
-  
+
 end function Aq_excit_2_janev
-  
+
 function Aq_excit_3_4_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=3\) state to the \(m=4\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3533,22 +3539,22 @@ function Aq_excit_3_4_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(6), parameter :: A = [1247.5d0, 11.319d0,   &
                                                    2.6235d0, 0.068781d0, &
                                                    0.521176d0, -1.2722d0 ]
-  
+
     real(Float64) :: Etil, qf, xsi
-  
+
     qf = real(q)
     etil = eb/qf
     xsi = 2.0**(0.397*(1 - sqrt(2.0/qf)))
     sigma = qf*1.e-16*xsi*A(1)*(exp(-A(2)/etil)*log(1+A(3)*etil)/etil &
           + A(4)*exp(-A(5)*etil)/etil**A(6))
-  
+
 end function Aq_excit_3_4_janev
-  
+
 function Aq_excit_3_5_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=3\) state to the \(m=5\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3564,22 +3570,22 @@ function Aq_excit_3_5_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(6), parameter :: A = [190.59d0, 11.096d0,   &
                                                    2.9098d0, 0.073307d0, &
                                                    0.54177d0, -1.2894d0 ]
-  
+
     real(Float64) :: Etil, qf, xsi
-  
+
     qf = real(q)
     etil = eb/qf
     xsi = 2.0**(0.397*(1 - sqrt(2.0/qf)))
     sigma = qf*1.e-16*xsi*A(1)*(exp(-A(2)/etil)*log(1+A(3)*etil)/etil &
           + A(4)*exp(-A(5)*etil)/etil**A(6))
-  
+
 end function Aq_excit_3_5_janev
-  
+
 function Aq_excit_3_6_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=3\) state to the \(m=6\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3595,22 +3601,22 @@ function Aq_excit_3_6_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(6), parameter :: A = [63.494d0, 11.507d0,   &
                                                    4.3417d0, 0.077953d0, &
                                                    0.53461d0, -1.2881d0 ]
-  
+
     real(Float64) :: Etil, qf, xsi
-  
+
     qf = real(q)
     etil = eb/qf
     xsi = 2.0**(0.397*(1 - sqrt(2.0/qf)))
     sigma = qf*1.e-16*xsi*A(1)*(exp(-A(2)/etil)*log(1+A(3)*etil)/etil &
           + A(4)*exp(-A(5)*etil)/etil**A(6))
-  
+
 end function Aq_excit_3_6_janev
-  
+
 function Aq_excit_3_7_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=3\) state to the \(m=7\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3626,17 +3632,17 @@ function Aq_excit_3_7_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 0.4670d0
-  
+
     real(Float64) :: hi
-  
+
     hi=2.0**(0.397*(1.0 - sqrt(2.0/q)))
     sigma=hi*A*Aq_excit_3_6_janev(eb, q)
-  
+
 end function Aq_excit_3_7_janev
-  
+
 function Aq_excit_3_8_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=3\) state to the \(m=8\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3652,17 +3658,17 @@ function Aq_excit_3_8_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 0.2545d0
-  
+
     real(Float64) :: hi
-  
+
     hi=2.0**(0.397*(1.0 - sqrt(2.0/q)))
     sigma=hi*A*Aq_excit_3_6_janev(eb, q)
-  
+
 end function Aq_excit_3_8_janev
-  
+
 function Aq_excit_3_9_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=3\) state to the \(m=9\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3678,17 +3684,17 @@ function Aq_excit_3_9_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-    
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 0.1540d0
-  
+
     real(Float64) :: hi
-  
+
     hi=2.0**(0.397*(1.0 - sqrt(2.0/q)))
     sigma=hi*A*Aq_excit_3_6_janev(eb, q)
-  
+
 end function Aq_excit_3_9_janev
-  
+
 function Aq_excit_3_10_janev(eb, q) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the \(n=3\) state to the \(m=10\) state due to a collision an ion with charge `q` at energy `eb`
@@ -3704,17 +3710,17 @@ function Aq_excit_3_10_janev(eb, q) result(sigma)
     integer, intent(in)       :: q
         !+ Ion charge
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-    
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), parameter :: A = 0.1d0
-  
+
     real(Float64) :: hi
-  
+
     hi=2.0**(0.397*(1.0 - sqrt(2.0/q)))
     sigma=hi*A*Aq_excit_3_6_janev(eb, q)
-  
+
 end function Aq_excit_3_10_janev
-  
+
 function Aq_excit_3_janev(eb, q, m_max) result(sigma)
     !+Calculates an array of the excitation cross sections for a neutral Hydrogen atom transitioning from
     !+the \(n=3\) state to the m=1..`m_max` states due to a collision an ion with charge `q` at energy `eb`
@@ -3734,10 +3740,10 @@ function Aq_excit_3_janev(eb, q, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refers to
-        !+an excitation from the \(n=3\) state to the m'th state [\(cm^2\)] 
-  
+        !+an excitation from the \(n=3\) state to the m'th state [\(cm^2\)]
+
     integer :: m
-  
+
     sigma = 0.d0
     do m=1,m_max
         select case (m)
@@ -3765,9 +3771,9 @@ function Aq_excit_3_janev(eb, q, m_max) result(sigma)
                 sigma(m) = sigma(10)*(10.0/m)**3.0
         end select
     enddo
-  
+
 end function Aq_excit_3_janev
-  
+
 function Aq_excit_n_janev(eb, q, n, m_max) result(sigma)
     !+Calculates an array of the generic excitation cross sections for a neutral Hydrogen atom transitioning from
     !+the `n` state to the m=1..`m_max` states due to a collision an ion with charge `q` at energy `eb`
@@ -3788,12 +3794,12 @@ function Aq_excit_n_janev(eb, q, n, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refers to
-        !+an excitation from the `n` state to the m'th state [\(cm^2\)] 
-  
+        !+an excitation from the `n` state to the m'th state [\(cm^2\)]
+
     integer :: m
     real(Float64) :: nf, mf, qf, etil, hi, s
     real(Float64) :: D, A, G, L, F, H, y, zpl, zmi, C2pl, C2mi
-  
+
     nf = real(n)
     qf = real(q)
     sigma = 0.d0
@@ -3813,7 +3819,7 @@ function Aq_excit_n_janev(eb, q, n, m_max) result(sigma)
         G = 0.5*(etil*nf**2.0 / (mf - 1.0/mf))**3.0
         L = log(1.0 + 0.53*etil**2.0 * nf*(mf - 2.0/mf )/(1.0 + 0.4*etil))
         F = (1.0 - 0.3*s*D/(nf*mf))**(1.0 + 2.0*s)
-        
+
         y = 1.0/(1.0 - D*log(18*s)/(4.0*s))
         zpl = 2.0/(etil*nf**2*(sqrt(2.0 - nf**2/mf**2) + 1.0))
         zmi = 2.0/(etil*nf**2*(sqrt(2.0 - nf**2/mf**2) - 1.0))
@@ -3823,9 +3829,9 @@ function Aq_excit_n_janev(eb, q, n, m_max) result(sigma)
 
         sigma(m) = q*hi*8.86e-17*nf**4/etil*(A*D*L+F*G*H)
     enddo m_loop
-  
+
 end function Aq_excit_n_janev
-  
+
 function Aq_excit_n(eb, q, n, m_max) result(sigma)
     !+Calculates an array of the excitation cross sections for a neutral Hydrogen atom transitioning from
     !+the `n` state to the m=1..`m_max` states due to a collision an ion with charge `q` at energy `eb`
@@ -3856,8 +3862,8 @@ function Aq_excit_n(eb, q, n, m_max) result(sigma)
         !+ Number of m states to calculate
     real(Float64), dimension(m_max) :: sigma
         !+ Array of cross sections where the m'th index refers to
-        !+an excitation from the `n` state to the m'th state [\(cm^2\)] 
-  
+        !+an excitation from the `n` state to the m'th state [\(cm^2\)]
+
     select case (n)
         case (0)
             stop
@@ -3870,9 +3876,9 @@ function Aq_excit_n(eb, q, n, m_max) result(sigma)
         case DEFAULT
             sigma = Aq_excit_n_janev(eb, q, n, m_max)
     end select
-  
+
 end function Aq_excit_n
-  
+
 function Aq_excit_n_m(eb ,q, n, m) result(sigma)
     !+Calculates the excitation cross section for a neutral Hydrogen atom transitioning from
     !+the `n`\(\rightarrow\)`m` state due to a collision an ion with charge `q` at energy `eb`
@@ -3902,19 +3908,19 @@ function Aq_excit_n_m(eb ,q, n, m) result(sigma)
     integer, intent(in)             :: m
         !+ Final atomic energy level/state
     real(Float64)             :: sigma
-        !+ Cross Section [\(cm^2\)]  
-  
+        !+ Cross Section [\(cm^2\)]
+
     real(Float64), dimension(12) :: sigma_m
-  
+
     sigma_m = Aq_excit_n(eb, q, n, 12)
     if(m.le.0) then
         sigma = sum(sigma_m)
     else
         sigma = sigma_m(m)
     endif
-  
+
 end function Aq_excit_n_m
-  
+
 function Aq_excit(eb, q, n_max, m_max) result(sigma)
     !+Calculates an matrix of the excitation cross sections for a neutral Hydrogen atom transitioning from
     !+the n=1..`n_max` state to the m=1..`m_max` states due to a collision an ion with charge `q` at energy `eb`
@@ -3940,24 +3946,93 @@ function Aq_excit(eb, q, n_max, m_max) result(sigma)
     integer, intent(in)                    :: q
         !+ Ion charge
     integer, intent(in)                    :: n_max
-        !+ Number of n states to calculate 
+        !+ Number of n states to calculate
     integer, intent(in)                    :: m_max
         !+ Number of m states to calculate
     real(Float64), dimension(n_max, m_max) :: sigma
         !+ Matrix of cross sections where the subscripts refers to
-        !+an excitation from the `n` state to the m'th state: Aq_excit[n,m] [\(cm^2\)] 
-  
+        !+an excitation from the `n` state to the m'th state: Aq_excit[n,m] [\(cm^2\)]
+
     real(Float64), dimension(12,12) :: sigma_full
     integer :: n, m
-  
+
     do n=1,12
         sigma_full(n,:) = Aq_excit_n(eb, q, n, 12)
     enddo
-  
+
     sigma = sigma_full(1:n_max,1:m_max)
-  
+
 end function Aq_excit
-  
+
+function d_d_fusion_t(eb) result(sigma)
+    !+Calculates total cross section at a given Deuterium energy, `eb`,
+    !+for the Tritium branch of Deuterium-Deutrium nuclear reactions
+    !+
+    !+###Equation
+    !+$$ D + D \rightarrow T(1.01 MeV) + p(3.02 MeV) (50%)$$
+    !+
+    !+###References
+    !+* Pages 44-45 in Ref. 7 [[atomic_tables(module)]]
+    real(Float64), intent(in) :: eb
+        !+ Deuterium energy [keV]
+    real(Float64)             :: sigma
+        !+ Cross Section [\(cm^2\)]
+
+    real(Float64), dimension(5), parameter :: A = [46.097d0, 372.0d0, &
+                                                   4.36d-4, 1.22d0,   &
+                                                   0.d0 ]
+
+    sigma = (1.0d-24)*(A(5) + (A(2)/((A(4) - A(3)*eb)**2.0 + 1.0))) / &
+            (eb*(exp(A(1)/sqrt(eb)) - 1.0))
+
+end function d_d_fusion_t
+
+function d_d_fusion_he(eb) result(sigma)
+    !+Calculates total cross section at a given deuterium energy, `eb`,
+    !+for the Helium-3 branch of Deuterium-Deutrium nuclear reactions
+    !+
+    !+###Equation
+    !+$$ D + D \rightarrow He^3(0.82 MeV) + n(2.45 MeV) (50%)$$
+    !+
+    !+###References
+    !+* Pages 44-45 in Ref. 7 [[atomic_tables(module)]]
+    real(Float64), intent(in) :: eb
+        !+ Deuterium energy [keV]
+    real(Float64)             :: sigma
+        !+ Cross Section [\(cm^2\)]
+
+    real(Float64), dimension(5), parameter :: A = [47.88d0, 482.0d0, &
+                                                   3.08d-4, 1.177d0, &
+                                                   0.d0 ]
+
+    sigma = (1.0d-24)*(A(5) + (A(2)/((A(4) - A(3)*eb)**2.0 + 1.0))) / &
+            (eb*(exp(A(1)/sqrt(eb)) - 1.0))
+
+end function d_d_fusion_he
+
+function d_t_fusion(eb) result(sigma)
+    !+Calculates total cross section at a given deuterium energy, `eb`,
+    !+for Deuterium-Tritium nuclear reactions
+    !+
+    !+###Equation
+    !+$$ D + T \rightarrow He^4(3.5 MeV) + n(14.1 MeV)$$
+    !+
+    !+###References
+    !+* Pages 44-45 in Ref. 7 [[atomic_tables(module)]]
+    real(Float64), intent(in) :: eb
+        !+ Deuterium energy [keV]
+    real(Float64)             :: sigma
+        !+ Cross Section [\(cm^2\)]
+
+    real(Float64), dimension(5), parameter :: A = [45.95d0, 5.02d4,   &
+                                                   1.368d-2, 1.076d0, &
+                                                   409.d0 ]
+
+    sigma = (1.0d-24)*(A(5) + (A(2)/((A(4) - A(3)*eb)**2.0 + 1.0))) / &
+            (eb*(exp(A(1)/sqrt(eb)) - 1.0))
+
+end function d_t_fusion
+
 function simpsons_rule(f, dx) result(I)
     !+ Performs 1D integration using Simpsons rule
     !+
@@ -3968,16 +4043,16 @@ function simpsons_rule(f, dx) result(I)
     real(Float64), intent(in)               :: dx
         !+ Spacing between x values
     real(Float64)                           :: I
-  
+
     integer :: s, ii
-  
+
     s = size(f)
     I = 0.d0
     if(mod(s,2).eq.1) then
         write(*,'(a)') "Length of array must be even"
         return
     endif
-  
+
     I = f(1)
     do ii=2,s-1
         if(mod(ii,2).eq.1) then
@@ -3988,11 +4063,85 @@ function simpsons_rule(f, dx) result(I)
     enddo
     I = I + f(s)
     I = (dx/3.0)*I
-    
+
 end function simpsons_rule
-  
+
+subroutine bt_maxwellian_eb(fn, T, eb, am, ab, rate)
+    !+ Calculates Maxwellian reaction rate for a beam with atomic mass `ab` and energy `eb`
+    !+firing into a target with atomic mass `am` and temperature `T` which has a cross section given by the function `fn`
+    interface
+        function fn(a)
+            !+Cross section function
+            real(8)              :: fn !sigma
+            real(8), intent(in)  :: a !eb
+        end function fn
+    end interface
+    real(Float64), intent(in)  :: T
+        !+Target temperature [keV]
+    real(Float64), intent(in)  :: eb
+        !+Beam energy [keV]
+    real(Float64), intent(in)  :: am
+        !+Target atomic mass [amu]
+    real(Float64), intent(in)  :: ab
+        !+Beam atomic mass [amu]
+    real(Float64), intent(out) :: rate
+        !+Reaction Rate [\(cm^3/s\)]
+
+    integer :: n_vr
+    real(Float64) :: vr_max, dvr
+    real(Float64), dimension(32) :: vr
+    real(Float64), dimension(32) :: fr
+    integer :: n_vz
+    real(Float64) :: vz_max,dvz
+    real(Float64), dimension(62) :: vz
+    real(Float64), dimension(62) :: fz
+    real(Float64) :: T_per_amu, eb_per_amu, ared, sig, sig_eff
+    real(Float64) :: zb, u2_to_erel, u2, erel, v_therm, dE
+
+    integer :: i, j
+
+    n_vr = 32
+    vr_max = 4.d0
+    dvr = vr_max/(n_vr - 1.d0)
+    do i=1,n_vr
+        vr(i) = (i-1)*dvr
+    enddo
+
+    n_vz = 62
+    vz_max = 4.d0
+    dvz = 2.0*vz_max/(n_vz - 1.d0)
+    do i=1,n_vz
+        vz(i) = (i-1)*dvz - vz_max
+    enddo
+
+    T_per_amu = max(T, 1.d-6)/am
+    eb_per_amu = eb/ab
+    ared = am*ab/(am + ab)
+
+    v_therm = 1.384d6 * sqrt(T_per_amu*1.d3)
+    zb = sqrt(eb_per_amu/T_per_amu)
+    u2_to_erel = ared*T_per_amu
+
+    fz = 0.d0
+    fr = 0.d0
+
+    do i=1,n_vz
+        do j=1,n_vr
+            u2 = (zb - vz(i))**2.0 + vr(j)**2.0
+            erel = u2_to_erel*u2
+            sig = fn(erel)
+            fr(j) = sig*sqrt(u2)*exp(-(vz(i)**2.0 + vr(j)**2.0))*vr(j)
+        enddo
+        fz(i) = simpsons_rule(fr, dvr)
+    enddo
+
+    sig_eff = (2.0/sqrt(PI))*simpsons_rule(fz, dvz)
+    rate = sig_eff*v_therm
+
+end subroutine bt_maxwellian_eb
+
 subroutine bt_maxwellian_n(fn, T, eb, am, ab, n, rate)
-    !+ Calculates Maxwellian reaction rate for a beam with atomic mass `ab`, energy `eb`, and energy level `n` 
+    !+ Calculates Maxwellian reaction rate for a beam with atomic mass `ab`, energy `eb`, and energy level `n`
     !+firing into a target with atomic mass `am` and temperature `T` which has a cross section given by the function `fn`
     interface
         function fn(a, b)
@@ -4023,39 +4172,39 @@ subroutine bt_maxwellian_n(fn, T, eb, am, ab, n, rate)
     integer :: n_vz
     real(Float64) :: vz_max,dvz
     real(Float64), dimension(62) :: vz
-    real(Float64), dimension(62) :: fz 
+    real(Float64), dimension(62) :: fz
     real(Float64) :: T_per_amu, eb_per_amu, ared, sig, sig_eff
     real(Float64) :: zb, u2_to_erel, u2, erel, v_therm, dE
-   
+
     integer :: i, j
-  
+
     n_vr = 32
     vr_max = 4.d0
     dvr = vr_max/(n_vr - 1.d0)
     do i=1,n_vr
         vr(i) = (i-1)*dvr
     enddo
-  
+
     n_vz = 62
     vz_max = 4.d0
     dvz = 2.0*vz_max/(n_vz - 1.d0)
     do i=1,n_vz
         vz(i) = (i-1)*dvz - vz_max
     enddo
-  
+
     T_per_amu = max(T, 1.d-6)/am
     eb_per_amu = eb/ab
     ared = am*ab/(am + ab)
     dE = (13.6d-3)/(n**2.0)
-  
+
     v_therm = 1.384d6 * sqrt(T_per_amu*1.d3)
     zb = sqrt(eb_per_amu/T_per_amu)
     u2_to_erel = ared*T_per_amu
     if(ared.lt.0.5) ared = 1.0 !for electron interactions
-  
+
     fz = 0.d0
     fr = 0.d0
-  
+
     do i=1,n_vz
         do j=1,n_vr
             u2 = (zb - vz(i))**2.0 + vr(j)**2.0
@@ -4069,14 +4218,14 @@ subroutine bt_maxwellian_n(fn, T, eb, am, ab, n, rate)
         enddo
         fz(i) = simpsons_rule(fr, dvr)
     enddo
-  
+
     sig_eff = (2.0/sqrt(PI))*simpsons_rule(fz, dvz)
     rate = sig_eff*v_therm
-    
+
 end subroutine bt_maxwellian_n
-  
+
 subroutine bt_maxwellian_q_n(fqn, q, T, eb, am, ab, n, rate)
-    !+ Calculates Maxwellian reaction rate for a beam with atomic mass `ab`, energy `eb`, and energy level `n` 
+    !+ Calculates Maxwellian reaction rate for a beam with atomic mass `ab`, energy `eb`, and energy level `n`
     !+firing into a target with atomic mass `am`, temperature `T`, and charge `q`  which has a cross section given by the function `fqn`
     interface
         function fqn(a, b, c)
@@ -4101,7 +4250,7 @@ subroutine bt_maxwellian_q_n(fqn, q, T, eb, am, ab, n, rate)
         !+Initial atomic energy level/state
     real(Float64), intent(out) :: rate
         !+Reaction Rate [\(cm^3/s\)]
-  
+
     integer :: n_vr
     real(Float64) :: vr_max, dvr
     real(Float64), dimension(32) :: vr
@@ -4109,39 +4258,39 @@ subroutine bt_maxwellian_q_n(fqn, q, T, eb, am, ab, n, rate)
     integer :: n_vz
     real(Float64) :: vz_max, dvz
     real(Float64), dimension(62) :: vz
-    real(Float64), dimension(62) :: fz 
+    real(Float64), dimension(62) :: fz
     real(Float64) :: T_per_amu, eb_per_amu, ared, sig, sig_eff
     real(Float64) :: zb, u2_to_erel, u2, erel, v_therm, dE
-   
+
     integer :: i, j
-  
+
     n_vr = 32
     vr_max = 4.d0
     dvr = vr_max/(n_vr - 1.d0)
     do i=1,n_vr
         vr(i) = (i-1)*dvr
     enddo
-  
+
     n_vz = 62
     vz_max = 4.d0
     dvz = 2.0*vz_max/(n_vz - 1.d0)
     do i=1,n_vz
         vz(i) = (i-1)*dvz - vz_max
     enddo
-  
+
     T_per_amu = max(T, 1.d-6)/am
     eb_per_amu = eb/ab
     ared = am*ab/(am + ab)
     dE = (13.6d-3)/(n**2.0)
-  
+
     v_therm = 1.384d6 * sqrt(T_per_amu*1.d3)
     zb = sqrt(eb_per_amu/T_per_amu)
     u2_to_erel = ared*T_per_amu
     if(ared.lt.0.5) ared = 1.0
-  
+
     fz = 0.d0
     fr = 0.d0
-  
+
     do i=1,n_vz
         do j=1,n_vr
             u2 = (zb - vz(i))**2.0 + vr(j)**2.0
@@ -4155,12 +4304,12 @@ subroutine bt_maxwellian_q_n(fqn, q, T, eb, am, ab, n, rate)
         enddo
         fz(i) = simpsons_rule(fr, dvr)
     enddo
-  
+
     sig_eff = (2.0/sqrt(PI))*simpsons_rule(fz, dvz)
     rate = sig_eff*v_therm
-  
+
 end subroutine bt_maxwellian_q_n
-  
+
 subroutine bt_maxwellian_n_m(fnm, T, eb, am, ab, n, m, rate, deexcit)
     !+ Calculates Maxwellian reaction rate for a `n`\(\rightarrow)`m` transition due to a beam with atomic mass `ab` and energy `eb`
     !+firing into a target with atomic mass `am` and temperature `T` which has a cross section given by the function `fnm`
@@ -4188,7 +4337,7 @@ subroutine bt_maxwellian_n_m(fnm, T, eb, am, ab, n, m, rate, deexcit)
     real(Float64), intent(out)    :: rate
         !+Reaction Rate [\(cm^3/s\)]
     logical, intent(in), optional :: deexcit
-        !+Calculate de-excitation reaction rate 
+        !+Calculate de-excitation reaction rate
 
     logical :: dxc
     integer :: n_vr
@@ -4198,48 +4347,48 @@ subroutine bt_maxwellian_n_m(fnm, T, eb, am, ab, n, m, rate, deexcit)
     integer :: n_vz
     real(Float64) :: vz_max, dvz
     real(Float64), dimension(62) :: vz
-    real(Float64), dimension(62) :: fz 
+    real(Float64), dimension(62) :: fz
     real(Float64) :: T_per_amu, eb_per_amu, ared, sig, sig_eff
     real(Float64) :: zb, u2_to_erel, u2, erel, dE, factor, En, Em, v_therm
-   
+
     integer :: i, j
-  
+
     if(present(deexcit)) then
         dxc = deexcit
     else
         dxc = .False.
     endif
-  
+
     n_vr = 32
     vr_max = 4.d0
     dvr = vr_max/(n_vr - 1.d0)
     do i=1,n_vr
         vr(i) = (i-1)*dvr
     enddo
-  
+
     n_vz = 62
     vz_max = 4.d0
     dvz = 2.0*vz_max/(n_vz - 1.d0)
     do i=1,n_vz
         vz(i) = (i-1)*dvz - vz_max
     enddo
-  
+
     En = (13.6d-3)*(1.0 - (1.d0/n)**2.0)
     Em = (13.6d-3)*(1.0 - (1.d0/m)**2.0)
     dE = Em - En
-  
+
     T_per_amu = max(T, 1.d-6)/am
     eb_per_amu = eb/ab
     ared = am*ab/(am + ab)
-  
+
     v_therm = 1.384d6 * sqrt(T_per_amu*1.d3)
     zb = sqrt(eb_per_amu/T_per_amu)
     u2_to_erel = ared*T_per_amu
     if(ared.lt.0.5) ared = 1.0
-  
+
     fz = 0.d0
     fr = 0.d0
-  
+
     do i=1,n_vz
         do j=1,n_vr
             u2 = (zb - vz(i))**2.0 + vr(j)**2.0
@@ -4259,13 +4408,13 @@ subroutine bt_maxwellian_n_m(fnm, T, eb, am, ab, n, m, rate, deexcit)
         enddo
         fz(i) = simpsons_rule(fr, dvr)
     enddo
-  
+
     sig_eff = (2.0/sqrt(PI))*simpsons_rule(fz, dvz)
     rate = sig_eff*v_therm
     if(dxc) rate = rate*(real(n)/real(m))**2.0
-  
+
 end subroutine bt_maxwellian_n_m
-  
+
 subroutine bt_maxwellian_q_n_m(fqnm, q, T, eb, am, ab, n, m, rate, deexcit)
     !+ Calculates Maxwellian reaction rate for a `n`\(\rightarrow)`m` transition due to a beam with atomic mass `ab` and energy `eb`
     !+firing into a target with atomic mass `am`, temperature `T`, and charge `q` which has a cross section given by the function `fqnm`
@@ -4296,7 +4445,7 @@ subroutine bt_maxwellian_q_n_m(fqnm, q, T, eb, am, ab, n, m, rate, deexcit)
     real(Float64), intent(out)    :: rate
         !+Reaction Rate [\(cm^3/s\)]
     logical, intent(in), optional :: deexcit
-        !+Calculate de-excitation reaction rate 
+        !+Calculate de-excitation reaction rate
 
     logical :: dxc
     integer :: n_vr
@@ -4306,48 +4455,48 @@ subroutine bt_maxwellian_q_n_m(fqnm, q, T, eb, am, ab, n, m, rate, deexcit)
     integer :: n_vz
     real(Float64) :: vz_max, dvz
     real(Float64), dimension(62) :: vz
-    real(Float64), dimension(62) :: fz 
+    real(Float64), dimension(62) :: fz
     real(Float64) :: T_per_amu, eb_per_amu, ared, sig, sig_eff
     real(Float64) :: zb, u2_to_erel, u2, erel, dE, factor, En, Em, v_therm
-   
+
     integer :: i, j
-  
+
     if(present(deexcit)) then
         dxc = deexcit
     else
         dxc = .False.
     endif
-  
+
     n_vr = 32
     vr_max = 4.d0
     dvr = vr_max/(n_vr - 1.d0)
     do i=1,n_vr
         vr(i) = (i-1)*dvr
     enddo
-  
+
     n_vz = 62
     vz_max = 4.d0
     dvz = 2.0*vz_max/(n_vz - 1.d0)
     do i=1,n_vz
         vz(i) = (i-1)*dvz - vz_max
     enddo
-  
+
     En = (13.6d-3)*(1.0 - (1.d0/n)**2.0)
     Em = (13.6d-3)*(1.0 - (1.d0/m)**2.0)
     dE = Em - En
-  
+
     T_per_amu = max(T, 1.d-6)/am
     eb_per_amu = eb/ab
     ared = am*ab/(am + ab)
-  
+
     v_therm = 1.384d6 * sqrt(T_per_amu*1.d3)
     zb = sqrt(eb_per_amu/T_per_amu)
     u2_to_erel = ared*T_per_amu
     if(ared.lt.0.5) ared = 1.0
-  
+
     fz = 0.d0
     fr = 0.d0
-  
+
     do i=1,n_vz
         do j=1,n_vr
             u2 = (zb - vz(i))**2.0 + vr(j)**2.0
@@ -4367,13 +4516,13 @@ subroutine bt_maxwellian_q_n_m(fqnm, q, T, eb, am, ab, n, m, rate, deexcit)
         enddo
         fz(i) = simpsons_rule(fr, dvr)
     enddo
-  
+
     sig_eff = (2.0/sqrt(PI))*simpsons_rule(fz, dvz)
     rate = sig_eff*v_therm
     if(dxc) rate = rate*(real(n)/real(m))**2.0
 
 end subroutine bt_maxwellian_q_n_m
-  
+
 subroutine write_einstein(id, n_max, m_max)
     !+ Write Einstein coefficients to HDF5 file
     integer(HID_T), intent(inout) :: id
@@ -4382,43 +4531,43 @@ subroutine write_einstein(id, n_max, m_max)
         !+ Number of initial atomic energy states to calculate
     integer, intent(in)           :: m_max
         !+ Number of final atomic energy states to calculate
-  
+
     real(Float64), dimension(n_max,m_max) :: ein
-  
+
     integer(HID_T) :: gid
     integer(HSIZE_T), dimension(1) :: dim1
     integer(HSIZE_T), dimension(2) :: dim2
     integer :: error
-  
+
     ein(:,:) = EINSTEIN(1:n_max,1:m_max)
-   
+
     call h5gcreate_f(id, "spontaneous", gid, error)
-  
+
     dim1 = [1]
     dim2 = [n_max, m_max]
-  
+
     call h5ltmake_dataset_int_f(gid, "n_max", 0, dim1, [n_max], error)
     call h5ltmake_dataset_int_f(gid, "m_max", 0, dim1, [m_max], error)
-  
+
     call h5ltmake_compressed_dataset_double_f(gid, "einstein", 2, dim2, ein, error)
-  
+
     call h5ltset_attribute_string_f(id, "spontaneous", "description", &
          "Atomic rates for spontaneous emission/deexcitation", error)
     call h5ltset_attribute_string_f(gid, "n_max", "description", &
          "Number of initial energy levels", error)
     call h5ltset_attribute_string_f(gid, "m_max", "description", &
          "Number of final energy levels", error)
-  
+
     call h5ltset_attribute_string_f(gid, "einstein", "description", &
          "n/m resolved einstein coefficients: einstein(n,m)", error)
     call h5ltset_attribute_string_f(gid, "einstein", "units", "1/s", error)
     call h5ltset_attribute_string_f(gid, "einstein", "reaction", &
          "H(n) -> H(m) + ph, n > m", error)
-  
+
     call h5gclose_f(gid, error)
-  
+
 end subroutine write_einstein
-  
+
 subroutine write_bb_H_H(id, namelist_file, n_max, m_max)
     !+ Write Hydrogen-Hydrogen interaction cross sections to a HDF5 file
     integer(HID_T), intent(inout) :: id
@@ -4433,19 +4582,19 @@ subroutine write_bb_H_H(id, namelist_file, n_max, m_max)
     real(Float64) :: emin
     real(Float64) :: emax
     integer :: nenergy
-  
+
     real(Float64) :: eb
     real(Float64) :: dlogE
     real(Float64), dimension(:), allocatable :: ebarr
-  
+
     real(Float64), dimension(:,:), allocatable :: ioniz
     real(Float64), dimension(:,:,:), allocatable :: cx, excit
-  
+
     integer(HID_T) :: gid
     integer(HSIZE_T), dimension(1) :: dim1
     integer(HSIZE_T), dimension(2) :: dim2
     integer(HSIZE_T), dimension(3) :: dim3
-  
+
     integer :: i, cnt, error
     logical :: exis
 
@@ -4472,7 +4621,7 @@ subroutine write_bb_H_H(id, namelist_file, n_max, m_max)
     ioniz = 0.d0
     cx = 0.d0
     excit = 0.d0
-  
+
     write(*,'(a)') "---- H-H cross sections settings ----"
     write(*,'(T2,"Emin = ",e9.2, " keV")') emin
     write(*,'(T2,"Emax = ",e9.2, " keV")') emax
@@ -4485,7 +4634,7 @@ subroutine write_bb_H_H(id, namelist_file, n_max, m_max)
     do i=1, nenergy
         eb = 10.d0**(log10(emin) + (i-1)*dlogE)
         ebarr(i) = eb
-  
+
         cx(:,:,i) = p_cx(eb, n_max, m_max)
         excit(:,:,i) = p_excit(eb, n_max, m_max)
         ioniz(:,i) = p_ioniz(eb, n_max)
@@ -4493,26 +4642,26 @@ subroutine write_bb_H_H(id, namelist_file, n_max, m_max)
         WRITE(*,'(f7.2,"%",a,$)') 100*cnt/real(nenergy),char(13)
     enddo
     !$OMP END PARALLEL DO
-  
+
     call h5gcreate_f(id, "H_H", gid, error)
-  
+
     dim1 = [1]
     dim2 = [n_max, nenergy]
     dim3 = [n_max, m_max, nenergy]
-  
+
     call h5ltmake_dataset_int_f(gid, "nenergy", 0, dim1, [nenergy], error)
     call h5ltmake_dataset_int_f(gid, "n_max", 0, dim1, [n_max], error)
     call h5ltmake_dataset_int_f(gid, "m_max", 0, dim1, [m_max], error)
     call h5ltmake_dataset_double_f(gid, "dlogE", 0, dim1, [dlogE], error)
     call h5ltmake_dataset_double_f(gid, "emin", 0, dim1, [emin], error)
     call h5ltmake_dataset_double_f(gid, "emax", 0, dim1, [emax], error)
-  
+
     dim1 = [nenergy]
     call h5ltmake_compressed_dataset_double_f(gid, "energy", 1, dim1, ebarr, error)
     call h5ltmake_compressed_dataset_double_f(gid, "cx", 3, dim3, cx, error)
     call h5ltmake_compressed_dataset_double_f(gid, "ionization", 2, dim2, ioniz, error)
     call h5ltmake_compressed_dataset_double_f(gid, "excitation", 3, dim3, excit, error)
-  
+
     call h5ltset_attribute_string_f(id, "H_H", "description", &
          "Cross sections for Hydrogen-Hydrogen interactions", error)
     call h5ltset_attribute_string_f(gid, "nenergy", "description", &
@@ -4529,35 +4678,35 @@ subroutine write_bb_H_H(id, namelist_file, n_max, m_max)
     call h5ltset_attribute_string_f(gid, "dlogE", "units", "log10(keV/amu)", error)
     call h5ltset_attribute_string_f(gid, "emin","description", &
          "Minimum energy", error)
-    call h5ltset_attribute_string_f(gid, "emin", "units", "keV/amu", error)  
+    call h5ltset_attribute_string_f(gid, "emin", "units", "keV/amu", error)
     call h5ltset_attribute_string_f(gid, "emax","description", &
          "Maximum energy", error)
-    call h5ltset_attribute_string_f(gid, "emax", "units", "keV/amu", error)  
-  
+    call h5ltset_attribute_string_f(gid, "emax", "units", "keV/amu", error)
+
     call h5ltset_attribute_string_f(gid, "cx", "description", &
          "n/m resolved charge exchange cross sections: cx(n,m,energy)", error)
     call h5ltset_attribute_string_f(gid, "cx", "units", "cm^2", error)
     call h5ltset_attribute_string_f(gid, "cx", "reaction", &
          "H(+) + H(n) -> H(m) + H(+)", error)
-  
+
     call h5ltset_attribute_string_f(gid, "excitation", "description", &
          "n/m resolved excitation cross sections: excitation(n,m,energy)", error)
     call h5ltset_attribute_string_f(gid, "excitation", "units", "cm^2", error)
     call h5ltset_attribute_string_f(gid, "excitation", "reaction", &
          "H(+) + H(n) -> H(+) + H(m), m > n", error)
-  
+
     call h5ltset_attribute_string_f(gid, "ionization", "description", &
          "n resolved ionization cross sections: ionization(n,energy)", error)
     call h5ltset_attribute_string_f(gid, "ionization", "units", "cm^2", error)
     call h5ltset_attribute_string_f(gid, "ionization", "reaction", &
          "H(+) + H(n) -> H(+) + H(+) + e-", error)
-  
+
     call h5gclose_f(gid, error)
-  
+
     deallocate(ebarr, cx, excit, ioniz)
 
 end subroutine write_bb_H_H
-  
+
 subroutine write_bb_H_e(id, namelist_file, n_max, m_max)
     !+ Write Hydrogen-Electron interaction cross sections to a HDF5 file
     integer(HID_T), intent(inout) :: id
@@ -4568,7 +4717,7 @@ subroutine write_bb_H_e(id, namelist_file, n_max, m_max)
         !+ Number of initial atomic energy states to calculate
     integer, intent(in)           :: m_max
         !+ Number of final atomic energy states to calculate
-  
+
     real(Float64) :: emin
     real(Float64) :: emax
     integer :: nenergy
@@ -4576,18 +4725,18 @@ subroutine write_bb_H_e(id, namelist_file, n_max, m_max)
     real(Float64) :: eb
     real(Float64) :: dlogE
     real(Float64), dimension(:), allocatable :: ebarr
-  
+
     real(Float64), dimension(:,:), allocatable :: ioniz
     real(Float64), dimension(:,:,:), allocatable :: excit
-  
+
     integer(HID_T) :: gid
     integer(HSIZE_T), dimension(1) :: dim1
     integer(HSIZE_T), dimension(2) :: dim2
     integer(HSIZE_T), dimension(3) :: dim3
-  
+
     integer :: i, cnt, error
     logical :: exis
-  
+
     NAMELIST /H_e_cross/ nenergy, emin, emax
 
     nenergy = 200; emin = 1.d-3 ; emax = 8.d2
@@ -4609,47 +4758,47 @@ subroutine write_bb_H_e(id, namelist_file, n_max, m_max)
     ebarr = 0.d0
     ioniz = 0.d0
     excit = 0.d0
-  
+
     write(*,'(a)') "---- H-e cross sections settings ----"
     write(*,'(T2,"Emin = ",e9.2, " keV")') emin
     write(*,'(T2,"Emax = ",e9.2, " keV")') emax
     write(*,'(T2,"Nenergy = ", i4)') nenergy
     write(*,*) ''
-  
+
     cnt = 0
     dlogE = (log10(emax) - log10(emin))/(nenergy - 1)
     !$OMP PARALLEL DO private(i, eb)
     do i=1, nenergy
         eb = 10.d0**(log10(emin) + (i-1)*dlogE)
         ebarr(i) = eb
-  
+
         excit(:,:,i) = e_excit(eb, n_max, m_max)
         ioniz(:,i) = e_ioniz(eb, n_max)
-  
+
         cnt = cnt + 1
         WRITE(*,'(f7.2,"%",a,$)') 100*cnt/real(nenergy),char(13)
     enddo
     !$OMP END PARALLEL DO
-  
+
     call h5gcreate_f(id, "H_e", gid, error)
-  
+
     dim1 = [1]
     dim2 = [n_max, nenergy]
     dim3 = [n_max, m_max, nenergy]
-  
+
     call h5ltmake_dataset_int_f(gid, "nenergy", 0, dim1, [nenergy], error)
     call h5ltmake_dataset_int_f(gid, "n_max", 0, dim1, [n_max], error)
     call h5ltmake_dataset_int_f(gid, "m_max", 0, dim1, [m_max], error)
     call h5ltmake_dataset_double_f(gid, "dlogE", 0, dim1, [dlogE], error)
     call h5ltmake_dataset_double_f(gid, "emin", 0, dim1, [emin], error)
     call h5ltmake_dataset_double_f(gid, "emax", 0, dim1, [emax], error)
-  
-  
+
+
     dim1 = [nenergy]
     call h5ltmake_compressed_dataset_double_f(gid, "energy", 1, dim1, ebarr, error)
     call h5ltmake_compressed_dataset_double_f(gid, "ionization", 2, dim2, ioniz, error)
     call h5ltmake_compressed_dataset_double_f(gid, "excitation", 3, dim3, excit, error)
-  
+
     call h5ltset_attribute_string_f(id, "H_e", "description", &
          "Cross sections for Hydrogen-Electron interactions", error)
     call h5ltset_attribute_string_f(gid, "nenergy", "description", &
@@ -4666,29 +4815,29 @@ subroutine write_bb_H_e(id, namelist_file, n_max, m_max)
     call h5ltset_attribute_string_f(gid, "dlogE", "units", "log10(keV/amu)", error)
     call h5ltset_attribute_string_f(gid, "emin","description", &
          "Minimum Energy", error)
-    call h5ltset_attribute_string_f(gid, "emin", "units", "keV/amu", error)  
+    call h5ltset_attribute_string_f(gid, "emin", "units", "keV/amu", error)
     call h5ltset_attribute_string_f(gid, "emax","description", &
          "Maximum Energy", error)
-    call h5ltset_attribute_string_f(gid, "emax", "units", "keV/amu", error)  
-  
+    call h5ltset_attribute_string_f(gid, "emax", "units", "keV/amu", error)
+
     call h5ltset_attribute_string_f(gid, "excitation", "description", &
          "n/m resolved excitation cross sections: excitation(n,m,energy)", error)
     call h5ltset_attribute_string_f(gid, "excitation", "units", "cm^2", error)
     call h5ltset_attribute_string_f(gid, "excitation", "reaction", &
          "e- + H(n) -> e- + H(m), m > n", error)
-  
+
     call h5ltset_attribute_string_f(gid, "ionization", "description", &
          "n resolved ionization cross sections: ionization(n,energy)", error)
     call h5ltset_attribute_string_f(gid, "ionization", "units", "cm^2", error)
     call h5ltset_attribute_string_f(gid, "ionization", "reaction", &
          "e- + H(n) -> e- + H(+) + e-", error)
-  
+
     call h5gclose_f(gid, error)
 
     deallocate(ebarr, ioniz, excit)
 
 end subroutine write_bb_H_e
-  
+
 subroutine write_bb_H_Aq(id, namelist_file, n_max, m_max)
     !+ Write Hydrogen-Impurity interaction cross sections to a HDF5 file
     integer(HID_T), intent(inout) :: id
@@ -4704,24 +4853,24 @@ subroutine write_bb_H_Aq(id, namelist_file, n_max, m_max)
     real(Float64) :: emin
     real(Float64) :: emax
     integer :: nenergy
-  
+
     real(Float64) :: eb
     real(Float64) :: dlogE
     real(Float64), dimension(:), allocatable :: ebarr
-  
+
     real(Float64), dimension(:,:), allocatable :: cx, ioniz
     real(Float64), dimension(:,:,:), allocatable :: excit
-  
+
     integer(HID_T) :: gid
     integer(HSIZE_T), dimension(1) :: dim1
     integer(HSIZE_T), dimension(2) :: dim2
     integer(HSIZE_T), dimension(3) :: dim3
-  
+
     character(len=10) :: aname
     character(len=5) :: asym
     integer :: i, cnt, error
     logical :: exis
-  
+
     NAMELIST /H_Aq_cross/ q, nenergy, emin, emax
 
     nenergy = 200; emin = 1.d-3 ; emax = 8.d2
@@ -4758,47 +4907,47 @@ subroutine write_bb_H_Aq(id, namelist_file, n_max, m_max)
             aname = "Impurity"
             asym = "H_Aq"
     end select
-  
+
     write(*,'(a)') "---- H-"//trim(adjustl(aname))//" cross sections settings ----"
     write(*,'(T2,"q = ", i2)'), q
     write(*,'(T2,"Emin = ",e9.2, " keV")') emin
     write(*,'(T2,"Emax = ",e9.2, " keV")') emax
     write(*,'(T2,"Nenergy = ", i4)') nenergy
     write(*,*) ''
-  
+
     cnt = 0
     dlogE = (log10(emax) - log10(emin))/(nenergy - 1)
     !$OMP PARALLEL DO private(i, eb)
     do i=1, nenergy
         eb = 10.d0**(log10(emin) + (i-1)*dlogE)
         ebarr(i) = eb
-  
+
         cx(:,i) = Aq_cx(eb, q, n_max)
         ioniz(:,i) = Aq_ioniz(eb, q, n_max)
         excit(:,:,i) = Aq_excit(eb, q, n_max, m_max)
         cnt = cnt + 1
         WRITE(*,'(f7.2,"%",a,$)') 100*cnt/real(nenergy),char(13)
     enddo
-  
+
     call h5gcreate_f(id, trim(adjustl(asym)), gid, error)
-  
+
     dim1 = [1]
     dim2 = [n_max, nenergy]
     dim3 = [n_max, m_max, nenergy]
-  
+
     call h5ltmake_dataset_int_f(gid, "nenergy", 0, dim1, [nenergy], error)
     call h5ltmake_dataset_int_f(gid, "n_max", 0, dim1, [n_max], error)
     call h5ltmake_dataset_int_f(gid, "m_max", 0, dim1, [m_max], error)
     call h5ltmake_dataset_double_f(gid, "dlogE", 0, dim1, [dlogE], error)
     call h5ltmake_dataset_double_f(gid, "emin", 0, dim1, [emin], error)
     call h5ltmake_dataset_double_f(gid, "emax", 0, dim1, [emax], error)
-  
+
     dim1 = [nenergy]
     call h5ltmake_compressed_dataset_double_f(gid, "energy", 1, dim1, ebarr, error)
     call h5ltmake_compressed_dataset_double_f(gid, "cx", 2, dim2, cx, error)
     call h5ltmake_compressed_dataset_double_f(gid, "ionization", 2, dim2, ioniz, error)
     call h5ltmake_compressed_dataset_double_f(gid, "excitation", 3, dim3, excit, error)
-  
+
     call h5ltset_attribute_string_f(id, trim(adjustl(asym)), "description", &
          "Cross sections for Hydrogen-"//trim(adjustl(aname))//" interactions", error)
     call h5ltset_attribute_string_f(gid, "nenergy", "description", &
@@ -4815,35 +4964,255 @@ subroutine write_bb_H_Aq(id, namelist_file, n_max, m_max)
     call h5ltset_attribute_string_f(gid, "dlogE", "units", "log10(keV/amu)", error)
     call h5ltset_attribute_string_f(gid, "emin","description", &
          "Minimum energy", error)
-    call h5ltset_attribute_string_f(gid, "emin", "units", "keV/amu", error)  
+    call h5ltset_attribute_string_f(gid, "emin", "units", "keV/amu", error)
     call h5ltset_attribute_string_f(gid, "emax","description", &
          "Maximum energy", error)
-    call h5ltset_attribute_string_f(gid, "emax", "units", "keV/amu", error)  
-  
+    call h5ltset_attribute_string_f(gid, "emax", "units", "keV/amu", error)
+
     call h5ltset_attribute_string_f(gid, "cx", "description", &
          "n resolved charge exchange / electron capture cross sections: cx(n,energy)", error)
     call h5ltset_attribute_string_f(gid, "cx", "units", "cm^2", error)
     call h5ltset_attribute_string_f(gid, "cx", "reaction", &
          "A(q+) + H(n) -> A((q-1)+) + H(+)", error)
-  
+
     call h5ltset_attribute_string_f(gid, "excitation", "description", &
          "n/m resolved excitation cross sections: excitation(n,m,energy)", error)
     call h5ltset_attribute_string_f(gid, "excitation", "units", "cm^2", error)
     call h5ltset_attribute_string_f(gid, "excitation", "reaction", &
          "A(q+) + H(n) -> A(q+) + H(m), m > n", error)
-  
+
     call h5ltset_attribute_string_f(gid, "ionization", "description", &
          "n resolved ionization cross sections: ionization(n,energy)", error)
     call h5ltset_attribute_string_f(gid, "ionization", "units", "cm^2", error)
     call h5ltset_attribute_string_f(gid, "ionization", "reaction", &
          "A(q+) + H(n) -> A(q+) + H(+) + e-", error)
-  
+
     call h5gclose_f(gid, error)
-  
+
     deallocate(ebarr, ioniz, cx, excit)
 
 end subroutine write_bb_H_Aq
-  
+
+subroutine write_bb_D_D(id, namelist_file)
+    !+ Write Deuterium-Deuterium interaction cross sections to a HDF5 file
+    integer(HID_T), intent(inout) :: id
+        !+ HDF5 file or group object id
+    character(len=*), intent(in)  :: namelist_file
+        !+ Namelist file that contains settings
+
+    integer :: nbranch = 2
+    real(Float64) :: emin
+    real(Float64) :: emax
+    integer :: nenergy
+
+    real(Float64) :: eb
+    real(Float64) :: dlogE
+    real(Float64), dimension(:), allocatable :: ebarr
+
+    real(Float64), dimension(:,:), allocatable :: fusion
+
+    integer(HID_T) :: gid
+    integer(HSIZE_T), dimension(1) :: dim1
+    integer(HSIZE_T), dimension(2) :: dim2
+
+    integer :: i, cnt, error
+    logical :: exis
+
+    NAMELIST /D_D_cross/ nenergy, emin, emax
+
+    nenergy = 200; emin = 1.d-3 ; emax = 8.d2
+
+    inquire(file=namelist_file,exist=exis)
+    if(.not.exis) then
+        write(*,'(a,a)') 'WRITE_BB_D_D: Input file does not exist: ',trim(namelist_file)
+        write(*,'(a)') 'Continuing with default settings...'
+    else
+        open(13,file=namelist_file)
+        read(13,NML=D_D_cross)
+        close(13)
+    endif
+
+    allocate(ebarr(nenergy))
+    allocate(fusion(nenergy,nbranch))
+
+    ebarr = 0.d0
+    fusion = 0.d0
+
+    write(*,'(a)') "---- D-D cross sections settings ----"
+    write(*,'(T2,"Emin = ",e9.2, " keV")') emin
+    write(*,'(T2,"Emax = ",e9.2, " keV")') emax
+    write(*,'(T2,"Nenergy = ", i4)') nenergy
+    write(*,*) ''
+
+    cnt = 0
+    dlogE = (log10(emax) - log10(emin))/(nenergy - 1)
+    !$OMP PARALLEL DO private(i, eb)
+    do i=1, nenergy
+        eb = 10.d0**(log10(emin) + (i-1)*dlogE)
+        ebarr(i) = eb
+
+        fusion(i,1) = d_d_fusion_t(eb)
+        fusion(i,2) = d_d_fusion_he(eb)
+        cnt = cnt + 1
+        WRITE(*,'(f7.2,"%",a,$)') 100*cnt/real(nenergy),char(13)
+    enddo
+    !$OMP END PARALLEL DO
+
+    call h5gcreate_f(id, "D_D", gid, error)
+
+    dim1 = [1]
+    call h5ltmake_dataset_int_f(gid, "nbranch", 0, dim1, [nbranch], error)
+    call h5ltmake_dataset_int_f(gid, "nenergy", 0, dim1, [nenergy], error)
+    call h5ltmake_dataset_double_f(gid, "dlogE", 0, dim1, [dlogE], error)
+    call h5ltmake_dataset_double_f(gid, "emin", 0, dim1, [emin], error)
+    call h5ltmake_dataset_double_f(gid, "emax", 0, dim1, [emax], error)
+
+    dim1 = [nenergy]
+    dim2 = [nenergy, nbranch]
+    call h5ltmake_compressed_dataset_double_f(gid, "energy", 1, dim1, ebarr, error)
+    call h5ltmake_compressed_dataset_double_f(gid, "fusion", 2, dim2, fusion, error)
+
+    call h5ltset_attribute_string_f(id, "D_D", "description", &
+         "Cross sections for Deuterium-Deuterium interactions", error)
+    call h5ltset_attribute_string_f(gid, "nbranch", "description", &
+         "Number of reaction branches", error)
+    call h5ltset_attribute_string_f(gid, "nenergy", "description", &
+         "Number of energy values", error)
+    call h5ltset_attribute_string_f(gid, "energy", "description", &
+         "Deuterium energy values", error)
+    call h5ltset_attribute_string_f(gid, "energy", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "dlogE", "description", &
+         "Energy spacing in log-10", error)
+    call h5ltset_attribute_string_f(gid, "dlogE", "units", "log10(keV)", error)
+    call h5ltset_attribute_string_f(gid, "emin","description", &
+         "Minimum energy", error)
+    call h5ltset_attribute_string_f(gid, "emin", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "emax","description", &
+         "Maximum energy", error)
+    call h5ltset_attribute_string_f(gid, "emax", "units", "keV", error)
+
+    call h5ltset_attribute_string_f(gid, "fusion", "description", &
+         "Cross sections for the Tritium[1] and He3[2] branches of D-D nuclear reactions: fusion(energy, branch)", error)
+    call h5ltset_attribute_string_f(gid, "fusion", "units", "cm^2", error)
+    call h5ltset_attribute_string_f(gid, "fusion", "reaction", &
+         "D + D -> [1] T(1.01 MeV) + p(3.02 MeV) (50%); [2] He3(0.82 MeV) + n(2.45 MeV) (50%)", error)
+
+    call h5gclose_f(gid, error)
+
+    deallocate(ebarr, fusion)
+
+end subroutine write_bb_D_D
+
+subroutine write_bb_D_T(id, namelist_file)
+    !+ Write Deuterium-Tritium interaction cross sections to a HDF5 file
+    integer(HID_T), intent(inout) :: id
+        !+ HDF5 file or group object id
+    character(len=*), intent(in)  :: namelist_file
+        !+ Namelist file that contains settings
+
+    integer :: nbranch = 1
+    real(Float64) :: emin
+    real(Float64) :: emax
+    integer :: nenergy
+
+    real(Float64) :: eb
+    real(Float64) :: dlogE
+    real(Float64), dimension(:), allocatable :: ebarr
+
+    real(Float64), dimension(:,:), allocatable :: fusion
+
+    integer(HID_T) :: gid
+    integer(HSIZE_T), dimension(1) :: dim1
+    integer(HSIZE_T), dimension(2) :: dim2
+
+    integer :: i, cnt, error
+    logical :: exis
+
+    NAMELIST /D_T_cross/ nenergy, emin, emax
+
+    nenergy = 200; emin = 1.d-3 ; emax = 8.d2
+
+    inquire(file=namelist_file,exist=exis)
+    if(.not.exis) then
+        write(*,'(a,a)') 'WRITE_BB_D_T: Input file does not exist: ',trim(namelist_file)
+        write(*,'(a)') 'Continuing with default settings...'
+    else
+        open(13,file=namelist_file)
+        read(13,NML=D_T_cross)
+        close(13)
+    endif
+
+    allocate(ebarr(nenergy))
+    allocate(fusion(nenergy,nbranch))
+
+    ebarr = 0.d0
+    fusion = 0.d0
+
+    write(*,'(a)') "---- D-T cross sections settings ----"
+    write(*,'(T2,"Emin = ",e9.2, " keV")') emin
+    write(*,'(T2,"Emax = ",e9.2, " keV")') emax
+    write(*,'(T2,"Nenergy = ", i4)') nenergy
+    write(*,*) ''
+
+    cnt = 0
+    dlogE = (log10(emax) - log10(emin))/(nenergy - 1)
+    !$OMP PARALLEL DO private(i, eb)
+    do i=1, nenergy
+        eb = 10.d0**(log10(emin) + (i-1)*dlogE)
+        ebarr(i) = eb
+
+        fusion(i,1) = d_t_fusion(eb)
+        cnt = cnt + 1
+        WRITE(*,'(f7.2,"%",a,$)') 100*cnt/real(nenergy),char(13)
+    enddo
+    !$OMP END PARALLEL DO
+
+    call h5gcreate_f(id, "D_T", gid, error)
+
+    dim1 = [1]
+
+    call h5ltmake_dataset_int_f(gid, "nbranch", 0, dim1, [nbranch], error)
+    call h5ltmake_dataset_int_f(gid, "nenergy", 0, dim1, [nenergy], error)
+    call h5ltmake_dataset_double_f(gid, "dlogE", 0, dim1, [dlogE], error)
+    call h5ltmake_dataset_double_f(gid, "emin", 0, dim1, [emin], error)
+    call h5ltmake_dataset_double_f(gid, "emax", 0, dim1, [emax], error)
+
+    dim1 = [nenergy]
+    dim2 = [nenergy, nbranch]
+    call h5ltmake_compressed_dataset_double_f(gid, "energy", 1, dim1, ebarr, error)
+    call h5ltmake_compressed_dataset_double_f(gid, "fusion", 2, dim2, fusion, error)
+
+    call h5ltset_attribute_string_f(id, "D_T", "description", &
+         "Cross sections for Deuterium-Tritium interactions", error)
+    call h5ltset_attribute_string_f(gid, "nbranch", "description", &
+         "Number of reaction branches", error)
+    call h5ltset_attribute_string_f(gid, "nenergy", "description", &
+         "Number of energy values", error)
+    call h5ltset_attribute_string_f(gid, "energy", "description", &
+         "Deuterium energy values", error)
+    call h5ltset_attribute_string_f(gid, "energy", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "dlogE", "description", &
+         "Energy spacing in log-10", error)
+    call h5ltset_attribute_string_f(gid, "dlogE", "units", "log10(keV)", error)
+    call h5ltset_attribute_string_f(gid, "emin","description", &
+         "Minimum energy", error)
+    call h5ltset_attribute_string_f(gid, "emin", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "emax","description", &
+         "Maximum energy", error)
+    call h5ltset_attribute_string_f(gid, "emax", "units", "keV", error)
+
+    call h5ltset_attribute_string_f(gid, "fusion", "description", &
+         "Total cross sections for D-T nuclear reactions: fusion(deuterium energy, branch)", error)
+    call h5ltset_attribute_string_f(gid, "fusion", "units", "cm^2", error)
+    call h5ltset_attribute_string_f(gid, "fusion", "reaction", &
+         "D + T -> He4(3.5 MeV) + n(14.1 MeV)", error)
+
+    call h5gclose_f(gid, error)
+
+    deallocate(ebarr, fusion)
+
+end subroutine write_bb_D_T
+
 subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
     !+ Write Hydrogen-Hydrogen reaction rates to a HDF5 file
     integer(HID_T), intent(inout) :: id
@@ -4862,25 +5231,25 @@ subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
     real(Float64) :: tmin
     real(Float64) :: tmax
     integer :: ntemp
-  
+
     real(Float64) :: eb
     real(Float64) :: dlogE
     real(Float64), dimension(:), allocatable :: ebarr
-  
+
     real(Float64) :: ti
     real(Float64) :: dlogT
     real(Float64), dimension(:), allocatable :: tarr
-  
+
     real(Float64), dimension(:,:,:,:), allocatable :: ioniz
     real(Float64), dimension(:,:,:,:,:), allocatable :: excit, cx
-  
+
     integer(HID_T) :: gid
     integer(HSIZE_T), dimension(1) :: dim1
     integer(HSIZE_T), dimension(2) :: dim2
     integer(HSIZE_T), dimension(3) :: dim3
     integer(HSIZE_T), dimension(4) :: dim4
     integer(HSIZE_T), dimension(5) :: dim5
-  
+
     integer :: ie, it, ia, n, m, error, cnt
     real(Float64) :: rate
     integer, parameter :: n_bt_amu = 4
@@ -4917,17 +5286,17 @@ subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
     a(:,2) = [H1_amu, H2_amu]
     a(:,3) = [H2_amu, H1_amu]
     a(:,4) = [H2_amu, H2_amu]
-     
+
     dlogE = (log10(emax) - log10(emin))/(nenergy - 1)
     do ie=1, nenergy
         ebarr(ie) = 10.d0**(log10(emin) + (ie-1)*dlogE)
     enddo
-  
+
     dlogT = (log10(tmax) - log10(tmin))/(ntemp - 1)
     do it=1, ntemp
         tarr(it) = 10.d0**(log10(tmin) + (it-1)*dlogT)
     enddo
-  
+
     write(*,'(a)') "---- H-H reaction rates settings ----"
     write(*,'(T2,"Emin = ",e9.2, " keV")') emin
     write(*,'(T2,"Emax = ",e9.2, " keV")') emax
@@ -4936,7 +5305,7 @@ subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
     write(*,'(T2,"Tmax = ",e9.2, " keV")') tmax
     write(*,'(T2,"Ntemp = ", i4)') ntemp
     write(*,*) ''
-  
+
     cnt = 0
     !$OMP PARALLEL DO private(ie, it, ia, n, m, eb, ti, rate)
     do ie=1, nenergy
@@ -4970,9 +5339,9 @@ subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
         enddo
     enddo
     !$OMP END PARALLEL DO
-  
+
     call h5gcreate_f(id, "H_H", gid, error)
-  
+
     dim1 = [1]
     dim4 = [n_max, nenergy, ntemp, n_bt_amu]
     dim5 = [n_max, m_max, nenergy, ntemp, n_bt_amu]
@@ -4987,9 +5356,9 @@ subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
     call h5ltmake_dataset_double_f(gid, "dlogT", 0, dim1, [dlogT], error)
     call h5ltmake_dataset_double_f(gid, "tmin", 0, dim1, [tmin], error)
     call h5ltmake_dataset_double_f(gid, "tmax", 0, dim1, [tmax], error)
-  
+
     dim2 = [2,n_bt_amu]
-    call h5ltmake_compressed_dataset_double_f(gid, "bt_amu", 2, dim2, a, error) 
+    call h5ltmake_compressed_dataset_double_f(gid, "bt_amu", 2, dim2, a, error)
     dim1 = [nenergy]
     call h5ltmake_compressed_dataset_double_f(gid, "energy", 1, dim1, ebarr, error)
     dim1 = [ntemp]
@@ -4997,9 +5366,9 @@ subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
     call h5ltmake_compressed_dataset_double_f(gid, "cx", 5, dim5, cx, error)
     call h5ltmake_compressed_dataset_double_f(gid, "ionization", 4, dim4, ioniz, error)
     call h5ltmake_compressed_dataset_double_f(gid, "excitation", 5, dim5, excit, error)
-  
+
     call h5ltset_attribute_string_f(id, "H_H", "description", &
-         "Reaction rates for Hydrogen(beam)-Hydrogen(target) interactions", error)
+         "Beam-Target reaction rates for Hydrogen(beam)-Hydrogen(target) interactions", error)
     call h5ltset_attribute_string_f(gid, "nenergy", "description", &
          "Number of energy values", error)
     call h5ltset_attribute_string_f(gid, "ntemp", "description", &
@@ -5010,7 +5379,7 @@ subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
          "Number of initial energy levels", error)
     call h5ltset_attribute_string_f(gid, "m_max", "description", &
          "Number of final energy levels", error)
-  
+
     call h5ltset_attribute_string_f(gid, "bt_amu", "description", &
          "Combinations of beam-target amu's e.g. b_amu, t_amu = bt_amu[:,i]", error)
     call h5ltset_attribute_string_f(gid, "energy", "description", &
@@ -5021,11 +5390,11 @@ subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
     call h5ltset_attribute_string_f(gid, "dlogE", "units", "log10(keV)", error)
     call h5ltset_attribute_string_f(gid, "emin","description", &
          "Minimum energy", error)
-    call h5ltset_attribute_string_f(gid, "emin", "units", "keV", error)  
+    call h5ltset_attribute_string_f(gid, "emin", "units", "keV", error)
     call h5ltset_attribute_string_f(gid, "emax","description", &
          "Maximum energy", error)
-    call h5ltset_attribute_string_f(gid, "emax", "units", "keV", error)  
-  
+    call h5ltset_attribute_string_f(gid, "emax", "units", "keV", error)
+
     call h5ltset_attribute_string_f(gid, "temperature", "description", &
          "Target temperature values", error)
     call h5ltset_attribute_string_f(gid, "temperature", "units", "keV", error)
@@ -5034,35 +5403,35 @@ subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
     call h5ltset_attribute_string_f(gid, "dlogT", "units", "log10(keV)", error)
     call h5ltset_attribute_string_f(gid, "tmin","description", &
          "Minimum temperature", error)
-    call h5ltset_attribute_string_f(gid, "tmin", "units", "keV", error)  
+    call h5ltset_attribute_string_f(gid, "tmin", "units", "keV", error)
     call h5ltset_attribute_string_f(gid, "tmax","description", &
          "Maximum temperature", error)
-    call h5ltset_attribute_string_f(gid, "tmax", "units", "keV", error)  
-  
+    call h5ltset_attribute_string_f(gid, "tmax", "units", "keV", error)
+
     call h5ltset_attribute_string_f(gid, "cx", "description", &
          "n/m resolved charge exchange reaction rates: cx(n,m,energy,temp,bt_amu)", error)
     call h5ltset_attribute_string_f(gid, "cx", "units", "cm^3/s", error)
     call h5ltset_attribute_string_f(gid, "cx", "reaction", &
          "H(+) + H(n) -> H(m) + H(+)", error)
-  
+
     call h5ltset_attribute_string_f(gid, "excitation", "description", &
          "n/m resolved (de-)excitation reaction rates: excitation(n,m,energy,temp,bt_amu)", error)
     call h5ltset_attribute_string_f(gid, "excitation", "units", "cm^3/s", error)
     call h5ltset_attribute_string_f(gid, "excitation", "reaction", &
          "H(+) + H(n) -> H(+) + H(m); m > n excitation, m < n de-excitation", error)
-  
+
     call h5ltset_attribute_string_f(gid, "ionization", "description", &
          "n resolved ionization reaction rates: ionization(n,energy,temp,bt_amu)", error)
     call h5ltset_attribute_string_f(gid, "ionization", "units", "cm^3/s", error)
     call h5ltset_attribute_string_f(gid, "ionization", "reaction", &
          "H(+) + H(n) -> H(+) + H(+) + e-", error)
-  
+
     call h5gclose_f(gid, error)
 
     deallocate(ebarr, tarr, cx, excit, ioniz)
 
 end subroutine write_bt_H_H
-  
+
 subroutine write_bt_H_e(id, namelist_file, n_max, m_max)
     !+ Write Hydrogen-Electron reaction rates to a HDF5 file
     integer(HID_T), intent(inout) :: id
@@ -5081,25 +5450,25 @@ subroutine write_bt_H_e(id, namelist_file, n_max, m_max)
     real(Float64) :: tmin
     real(Float64) :: tmax
     integer :: ntemp
-  
+
     real(Float64) :: eb
     real(Float64) :: dlogE
     real(Float64), dimension(:), allocatable :: ebarr
-  
+
     real(Float64) :: ti
     real(Float64) :: dlogT
     real(Float64), dimension(:), allocatable :: tarr
-  
+
     real(Float64), dimension(:,:,:,:), allocatable :: ioniz
     real(Float64), dimension(:,:,:,:,:), allocatable :: excit
-  
+
     integer(HID_T) :: gid
     integer(HSIZE_T), dimension(1) :: dim1
     integer(HSIZE_T), dimension(2) :: dim2
     integer(HSIZE_T), dimension(3) :: dim3
     integer(HSIZE_T), dimension(4) :: dim4
     integer(HSIZE_T), dimension(5) :: dim5
-  
+
     integer :: ie, it, ia, n, m, error, cnt
     real(Float64) :: rate
     integer, parameter :: n_bt_amu = 2
@@ -5125,23 +5494,23 @@ subroutine write_bt_H_e(id, namelist_file, n_max, m_max)
     allocate(tarr(ntemp))
     allocate(ioniz(n_max,nenergy,ntemp,n_bt_amu))
     allocate(excit(n_max,m_max,nenergy,ntemp,n_bt_amu))
-  
+
     ebarr = 0.d0
     ioniz = 0.d0
     excit = 0.d0
     a(:,1) = [H1_amu, e_amu]
     a(:,2) = [H2_amu, e_amu]
-     
+
     dlogE = (log10(emax) - log10(emin))/(nenergy - 1)
     do ie=1, nenergy
         ebarr(ie) = 10.d0**(log10(emin) + (ie-1)*dlogE)
     enddo
-  
+
     dlogT = (log10(tmax) - log10(tmin))/(ntemp - 1)
     do it=1, ntemp
         tarr(it) = 10.d0**(log10(tmin) + (it-1)*dlogT)
     enddo
-  
+
     write(*,'(a)') "---- H-e reaction rates settings ----"
     write(*,'(T2,"Emin = ",e9.2, " keV")') emin
     write(*,'(T2,"Emax = ",e9.2, " keV")') emax
@@ -5150,7 +5519,7 @@ subroutine write_bt_H_e(id, namelist_file, n_max, m_max)
     write(*,'(T2,"Tmax = ",e9.2, " keV")') tmax
     write(*,'(T2,"Ntemp = ", i4)') ntemp
     write(*,*) ''
-  
+
     cnt = 0
     !$OMP PARALLEL DO private(ie, it, ia, n, m, eb, ti, rate)
     do ie=1, nenergy
@@ -5181,9 +5550,9 @@ subroutine write_bt_H_e(id, namelist_file, n_max, m_max)
         enddo
     enddo
     !$OMP END PARALLEL DO
-  
+
     call h5gcreate_f(id, "H_e", gid, error)
-  
+
     dim1 = [1]
     dim4 = [n_max, nenergy, ntemp, n_bt_amu]
     dim5 = [n_max, m_max, nenergy, ntemp, n_bt_amu]
@@ -5198,18 +5567,18 @@ subroutine write_bt_H_e(id, namelist_file, n_max, m_max)
     call h5ltmake_dataset_double_f(gid, "dlogT", 0, dim1, [dlogT], error)
     call h5ltmake_dataset_double_f(gid, "tmin", 0, dim1, [tmin], error)
     call h5ltmake_dataset_double_f(gid, "tmax", 0, dim1, [tmax], error)
-  
+
     dim2 = [2,n_bt_amu]
-    call h5ltmake_compressed_dataset_double_f(gid, "bt_amu", 2, dim2, a, error) 
+    call h5ltmake_compressed_dataset_double_f(gid, "bt_amu", 2, dim2, a, error)
     dim1 = [nenergy]
     call h5ltmake_compressed_dataset_double_f(gid, "energy", 1, dim1, ebarr, error)
     dim1 = [ntemp]
     call h5ltmake_compressed_dataset_double_f(gid, "temperature", 1, dim1, tarr, error)
     call h5ltmake_compressed_dataset_double_f(gid, "ionization", 4, dim4, ioniz, error)
     call h5ltmake_compressed_dataset_double_f(gid, "excitation", 5, dim5, excit, error)
-  
+
     call h5ltset_attribute_string_f(id, "H_e", "description", &
-         "Reaction rates for Hydrogen(beam)-Electron(target) interactions", error)
+         "Beam-Target reaction rates for Hydrogen(beam)-Electron(target) interactions", error)
     call h5ltset_attribute_string_f(gid, "nenergy", "description", &
          "Number of energy values", error)
     call h5ltset_attribute_string_f(gid, "ntemp", "description", &
@@ -5220,7 +5589,7 @@ subroutine write_bt_H_e(id, namelist_file, n_max, m_max)
          "Number of initial energy levels", error)
     call h5ltset_attribute_string_f(gid, "m_max", "description", &
          "Number of final energy levels", error)
-  
+
     call h5ltset_attribute_string_f(gid, "bt_amu", "description", &
          "Combinations of beam-target amu's e.g. b_amu, t_amu = bt_amu[:,i]", error)
     call h5ltset_attribute_string_f(gid, "energy", "description", &
@@ -5231,11 +5600,11 @@ subroutine write_bt_H_e(id, namelist_file, n_max, m_max)
     call h5ltset_attribute_string_f(gid, "dlogE", "units", "log10(keV)", error)
     call h5ltset_attribute_string_f(gid, "emin","description", &
          "Minimum energy", error)
-    call h5ltset_attribute_string_f(gid, "emin", "units", "keV", error)  
+    call h5ltset_attribute_string_f(gid, "emin", "units", "keV", error)
     call h5ltset_attribute_string_f(gid, "emax","description", &
          "Maximum energy", error)
-    call h5ltset_attribute_string_f(gid, "emax", "units", "keV", error)  
-  
+    call h5ltset_attribute_string_f(gid, "emax", "units", "keV", error)
+
     call h5ltset_attribute_string_f(gid, "temperature", "description", &
          "Target temperature values", error)
     call h5ltset_attribute_string_f(gid, "temperature", "units", "keV", error)
@@ -5244,29 +5613,29 @@ subroutine write_bt_H_e(id, namelist_file, n_max, m_max)
     call h5ltset_attribute_string_f(gid, "dlogT", "units", "log10(keV)", error)
     call h5ltset_attribute_string_f(gid, "tmin","description", &
          "Minimum temperature", error)
-    call h5ltset_attribute_string_f(gid, "tmin", "units", "keV", error)  
+    call h5ltset_attribute_string_f(gid, "tmin", "units", "keV", error)
     call h5ltset_attribute_string_f(gid, "tmax","description", &
          "Maximum temperature", error)
-    call h5ltset_attribute_string_f(gid, "tmax", "units", "keV", error)  
-  
+    call h5ltset_attribute_string_f(gid, "tmax", "units", "keV", error)
+
     call h5ltset_attribute_string_f(gid, "excitation", "description", &
          "n/m resolved (de-)excitation reaction rates: excitation(n,m,energy,temp,bt_amu)", error)
     call h5ltset_attribute_string_f(gid, "excitation", "units", "cm^3/s", error)
     call h5ltset_attribute_string_f(gid, "excitation", "reaction", &
          "e- + H(n) -> e- + H(m); m > n excitation, m < n de-excitation", error)
-  
+
     call h5ltset_attribute_string_f(gid, "ionization", "description", &
          "n resolved ionization reaction rates: ionization(n,energy,temp,bt_amu)", error)
     call h5ltset_attribute_string_f(gid, "ionization", "units", "cm^3/s", error)
     call h5ltset_attribute_string_f(gid, "ionization", "reaction", &
          "e- + H(n) -> e- + H(+) + e-", error)
-  
+
     call h5gclose_f(gid, error)
-  
+
     deallocate(ebarr, tarr, excit, ioniz)
 
 end subroutine write_bt_H_e
-  
+
 subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
     !+ Write Hydrogen-Impurity reaction rates to a HDF5 file
     integer(HID_T), intent(inout) :: id
@@ -5288,30 +5657,30 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
     real(Float64) :: tmin
     real(Float64) :: tmax
     integer :: ntemp
-  
+
     real(Float64) :: eb
     real(Float64) :: dlogE
     real(Float64), dimension(:), allocatable :: ebarr
-  
+
     real(Float64) :: ti
     real(Float64) :: dlogT
     real(Float64), dimension(:), allocatable :: tarr
-  
+
     real(Float64), dimension(:,:,:,:), allocatable :: ioniz, cx
     real(Float64), dimension(:,:,:,:,:), allocatable :: excit
-  
+
     integer(HID_T) :: gid
     integer(HSIZE_T), dimension(1) :: dim1
     integer(HSIZE_T), dimension(2) :: dim2
     integer(HSIZE_T), dimension(3) :: dim3
     integer(HSIZE_T), dimension(4) :: dim4
     integer(HSIZE_T), dimension(5) :: dim5
-  
+
     integer :: ie, it, ia, n, m, error, cnt
     real(Float64) :: rate
     integer, parameter :: n_bt_amu = 2
     real(Float64), dimension(2,n_bt_amu) :: a
-  
+
     character(len=10) :: aname
     character(len=5) :: asym
     logical :: exis
@@ -5336,8 +5705,8 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
     allocate(ioniz(n_max,nenergy,ntemp,n_bt_amu))
     allocate(cx(n_max,nenergy,ntemp,n_bt_amu))
     allocate(excit(n_max,m_max,nenergy,ntemp,n_bt_amu))
-  
-  
+
+
     select case (q)
       case (5)
           aname = "Boron"
@@ -5349,19 +5718,19 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
           aname = "Impurity"
           asym = "H_Aq"
     end select
-  
+
     ebarr = 0.d0
     ioniz = 0.d0
     cx = 0.d0
     excit = 0.d0
     a(:,1) = [H1_amu, mass]
     a(:,2) = [H2_amu, mass]
-     
+
     dlogE = (log10(emax) - log10(emin))/(nenergy - 1)
     do ie=1, nenergy
         ebarr(ie) = 10.d0**(log10(emin) + (ie-1)*dlogE)
     enddo
-  
+
     dlogT = (log10(tmax) - log10(tmin))/(ntemp - 1)
     do it=1, ntemp
         tarr(it) = 10.d0**(log10(tmin) + (it-1)*dlogT)
@@ -5376,7 +5745,7 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
     write(*,'(T2,"Tmax = ",e9.2, " keV")') tmax
     write(*,'(T2,"Ntemp = ", i4)') ntemp
     write(*,*) ''
-  
+
     cnt = 0
     !$OMP PARALLEL DO private(ie, it, ia, n, m, eb, ti, rate)
     do ie=1, nenergy
@@ -5411,9 +5780,9 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
         enddo
     enddo
     !$OMP END PARALLEL DO
-  
+
     call h5gcreate_f(id, trim(adjustl(asym)), gid, error)
-  
+
     dim1 = [1]
     dim4 = [n_max, nenergy, ntemp, n_bt_amu]
     dim5 = [n_max, m_max, nenergy, ntemp, n_bt_amu]
@@ -5428,9 +5797,9 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
     call h5ltmake_dataset_double_f(gid, "dlogT", 0, dim1, [dlogT], error)
     call h5ltmake_dataset_double_f(gid, "tmin", 0, dim1, [tmin], error)
     call h5ltmake_dataset_double_f(gid, "tmax", 0, dim1, [tmax], error)
-  
+
     dim2 = [2,n_bt_amu]
-    call h5ltmake_compressed_dataset_double_f(gid, "bt_amu", 2, dim2, a, error) 
+    call h5ltmake_compressed_dataset_double_f(gid, "bt_amu", 2, dim2, a, error)
     dim1 = [nenergy]
     call h5ltmake_compressed_dataset_double_f(gid, "energy", 1, dim1, ebarr, error)
     dim1 = [ntemp]
@@ -5438,9 +5807,9 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
     call h5ltmake_compressed_dataset_double_f(gid, "cx", 4, dim4, cx, error)
     call h5ltmake_compressed_dataset_double_f(gid, "ionization", 4, dim4, ioniz, error)
     call h5ltmake_compressed_dataset_double_f(gid, "excitation", 5, dim5, excit, error)
-  
+
     call h5ltset_attribute_string_f(id, trim(adjustl(asym)), "description", &
-         "Reaction rates for Hydrogen(beam)-"//trim(adjustl(aname))// &
+         "Beam-Target reaction rates for Hydrogen(beam)-"//trim(adjustl(aname))// &
          "(target) interactions", error)
     call h5ltset_attribute_string_f(gid, "nenergy", "description", &
          "Number of energy values", error)
@@ -5452,7 +5821,7 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
          "Number of initial energy levels", error)
     call h5ltset_attribute_string_f(gid, "m_max", "description", &
          "Number of final energy levels", error)
-  
+
     call h5ltset_attribute_string_f(gid, "bt_amu", "description", &
          "Combinations of beam-target amu's e.g. b_amu, t_amu = bt_amu[:,i]", error)
     call h5ltset_attribute_string_f(gid, "energy", "description", &
@@ -5463,11 +5832,11 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
     call h5ltset_attribute_string_f(gid, "dlogE", "units", "log10(keV)", error)
     call h5ltset_attribute_string_f(gid, "emin","description", &
          "Minimum energy", error)
-    call h5ltset_attribute_string_f(gid, "emin", "units", "keV", error)  
+    call h5ltset_attribute_string_f(gid, "emin", "units", "keV", error)
     call h5ltset_attribute_string_f(gid, "emax","description", &
          "Maximum energy", error)
-    call h5ltset_attribute_string_f(gid, "emax", "units", "keV", error)  
-  
+    call h5ltset_attribute_string_f(gid, "emax", "units", "keV", error)
+
     call h5ltset_attribute_string_f(gid, "temperature", "description", &
          "Target temperature values", error)
     call h5ltset_attribute_string_f(gid, "temperature", "units", "keV", error)
@@ -5476,34 +5845,364 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
     call h5ltset_attribute_string_f(gid, "dlogT", "units", "log10(keV)", error)
     call h5ltset_attribute_string_f(gid, "tmin","description", &
          "Minimum temperature", error)
-    call h5ltset_attribute_string_f(gid, "tmin", "units", "keV", error)  
+    call h5ltset_attribute_string_f(gid, "tmin", "units", "keV", error)
     call h5ltset_attribute_string_f(gid, "tmax","description", &
          "Maximum temperature", error)
-    call h5ltset_attribute_string_f(gid, "tmax", "units", "keV", error)  
-  
+    call h5ltset_attribute_string_f(gid, "tmax", "units", "keV", error)
+
     call h5ltset_attribute_string_f(gid, "cx", "description", &
          "n-resolved charge exchange reaction rates: cx(n,energy,temp,bt_amu)", error)
     call h5ltset_attribute_string_f(gid, "cx", "units", "cm^3/s", error)
     call h5ltset_attribute_string_f(gid, "cx", "reaction", &
          "A(q+) + H(n) -> A((q-1)+) + H(+)", error)
-  
+
     call h5ltset_attribute_string_f(gid, "excitation", "description", &
          "n/m resolved (de-)excitation reaction rates: excitation(n,m,energy,temp,bt_amu)", error)
     call h5ltset_attribute_string_f(gid, "excitation", "units", "cm^3/s", error)
     call h5ltset_attribute_string_f(gid, "excitation", "reaction", &
          "A(q+) + H(n) -> A(q+) + H(m); m > n excitation, m < n de-excitation", error)
-  
+
     call h5ltset_attribute_string_f(gid, "ionization", "description", &
          "n resolved ionization reaction rates: ionization(n,energy,temp,bt_amu)", error)
     call h5ltset_attribute_string_f(gid, "ionization", "units", "cm^3/s", error)
     call h5ltset_attribute_string_f(gid, "ionization", "reaction", &
          "A(q+) + H(n) -> A(q+) + H(+) + e-", error)
-  
+
     call h5gclose_f(gid, error)
-  
+
     deallocate(ebarr, tarr, excit, ioniz)
 
 end subroutine write_bt_H_Aq
+
+subroutine write_bt_D_D(id, namelist_file)
+    !+ Write Deuterium-Deuterium reaction rates to a HDF5 file
+    integer(HID_T), intent(inout) :: id
+        !+ HDF5 file or group object id
+    character(len=*), intent(in)  :: namelist_file
+        !+ Namelist file that contains settings
+
+    integer :: nbranch = 2
+    real(Float64), dimension(2) :: bt_amu = [H2_amu, H2_amu]
+
+    real(Float64) :: emin
+    real(Float64) :: emax
+    integer :: nenergy
+
+    real(Float64) :: tmin
+    real(Float64) :: tmax
+    integer :: ntemp
+
+    real(Float64) :: eb
+    real(Float64) :: dlogE
+    real(Float64), dimension(:), allocatable :: ebarr
+
+    real(Float64) :: ti
+    real(Float64) :: dlogT
+    real(Float64), dimension(:), allocatable :: tarr
+
+    real(Float64), dimension(:,:,:), allocatable :: fusion
+
+    integer(HID_T) :: gid
+    integer(HSIZE_T), dimension(1) :: dim1
+    integer(HSIZE_T), dimension(3) :: dim3
+
+    integer :: ie, it, error, cnt
+    real(Float64) :: rate_a, rate_b
+    logical :: exis
+
+    NAMELIST /D_D_rates/ nenergy, emin, emax, ntemp, tmin, tmax
+
+    nenergy = 100; emin = 1.d-3 ; emax = 4.d2
+    ntemp = 100; tmin = 1.d-3 ; tmax = 2.d1
+
+    inquire(file=namelist_file,exist=exis)
+    if(.not.exis) then
+        write(*,'(a,a)') 'WRITE_BT_D_D: Input file does not exist: ',trim(namelist_file)
+        write(*,'(a)') 'Continuing with default settings...'
+    else
+        open(13,file=namelist_file)
+        read(13,NML=D_D_rates)
+        close(13)
+    endif
+
+    allocate(ebarr(nenergy))
+    allocate(tarr(ntemp))
+    allocate(fusion(nenergy,ntemp,nbranch))
+
+    ebarr = 0.d0
+    tarr = 0.d0
+    fusion = 0.d0
+
+    dlogE = (log10(emax) - log10(emin))/(nenergy - 1)
+    do ie=1, nenergy
+        ebarr(ie) = 10.d0**(log10(emin) + (ie-1)*dlogE)
+    enddo
+
+    dlogT = (log10(tmax) - log10(tmin))/(ntemp - 1)
+    do it=1, ntemp
+        tarr(it) = 10.d0**(log10(tmin) + (it-1)*dlogT)
+    enddo
+
+    write(*,'(a)') "---- D-D reaction rates settings ----"
+    write(*,'(T2,"Emin = ",e9.2, " keV")') emin
+    write(*,'(T2,"Emax = ",e9.2, " keV")') emax
+    write(*,'(T2,"Nenergy = ", i4)') nenergy
+    write(*,'(T2,"Tmin = ",e9.2, " keV")') tmin
+    write(*,'(T2,"Tmax = ",e9.2, " keV")') tmax
+    write(*,'(T2,"Ntemp = ", i4)') ntemp
+    write(*,*) ''
+
+    cnt = 0
+    !$OMP PARALLEL DO private(ie, it, eb, ti, rate_a, rate_b)
+    do ie=1, nenergy
+        eb = ebarr(ie)
+        do it=1, ntemp
+            ti = tarr(it)
+            call bt_maxwellian(d_d_fusion_t, ti, eb, bt_amu(1), bt_amu(2), rate_a)
+            call bt_maxwellian(d_d_fusion_he, ti, eb, bt_amu(2), bt_amu(2), rate_b)
+            fusion(ie,it,1) = rate_a
+            fusion(ie,it,2) = rate_b
+            cnt = cnt + 1
+            WRITE(*,'(f7.2,"%",a,$)') 100*cnt/real(nenergy*ntemp),char(13)
+        enddo
+    enddo
+    !$OMP END PARALLEL DO
+
+    call h5gcreate_f(id, "D_D", gid, error)
+
+    dim1 = [1]
+    call h5ltmake_dataset_int_f(gid, "nbranch", 0, dim1, [nbranch], error)
+    call h5ltmake_dataset_int_f(gid, "nenergy", 0, dim1, [nenergy], error)
+    call h5ltmake_dataset_int_f(gid, "ntemp", 0, dim1, [ntemp], error)
+    call h5ltmake_dataset_double_f(gid, "dlogE", 0, dim1, [dlogE], error)
+    call h5ltmake_dataset_double_f(gid, "emin", 0, dim1, [emin], error)
+    call h5ltmake_dataset_double_f(gid, "emax", 0, dim1, [emax], error)
+    call h5ltmake_dataset_double_f(gid, "dlogT", 0, dim1, [dlogT], error)
+    call h5ltmake_dataset_double_f(gid, "tmin", 0, dim1, [tmin], error)
+    call h5ltmake_dataset_double_f(gid, "tmax", 0, dim1, [tmax], error)
+
+    dim1 = [2]
+    call h5ltmake_compressed_dataset_double_f(gid, "bt_amu", 1, dim1, bt_amu, error)
+    dim1 = [nenergy]
+    call h5ltmake_compressed_dataset_double_f(gid, "energy", 1, dim1, ebarr, error)
+    dim1 = [ntemp]
+    call h5ltmake_compressed_dataset_double_f(gid, "temperature", 1, dim1, tarr, error)
+    dim3 = [nenergy, ntemp, nbranch]
+    call h5ltmake_compressed_dataset_double_f(gid, "fusion", 3, dim3, fusion, error)
+
+    call h5ltset_attribute_string_f(id, "D_D", "description", &
+         "Beam-Target reaction rates for Deuterium(beam)-Deuterium(target) interactions", error)
+    call h5ltset_attribute_string_f(gid, "nbranch", "description", &
+         "Number of reaction branches", error)
+    call h5ltset_attribute_string_f(gid, "nenergy", "description", &
+         "Number of energy values", error)
+    call h5ltset_attribute_string_f(gid, "ntemp", "description", &
+         "Number of target temperature values", error)
+    call h5ltset_attribute_string_f(gid, "energy", "description", &
+         "Energy values", error)
+    call h5ltset_attribute_string_f(gid, "energy", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "dlogE", "description", &
+         "Energy spacing in log-10", error)
+    call h5ltset_attribute_string_f(gid, "dlogE", "units", "log10(keV)", error)
+    call h5ltset_attribute_string_f(gid, "emin","description", &
+         "Minimum energy", error)
+    call h5ltset_attribute_string_f(gid, "emin", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "emax","description", &
+         "Maximum energy", error)
+    call h5ltset_attribute_string_f(gid, "emax", "units", "keV", error)
+
+    call h5ltset_attribute_string_f(gid, "temperature", "description", &
+         "Target temperature values", error)
+    call h5ltset_attribute_string_f(gid, "temperature", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "dlogT", "description", &
+         "Temperature spacing in log-10", error)
+    call h5ltset_attribute_string_f(gid, "dlogT", "units", "log10(keV)", error)
+    call h5ltset_attribute_string_f(gid, "tmin","description", &
+         "Minimum temperature", error)
+    call h5ltset_attribute_string_f(gid, "tmin", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "tmax","description", &
+         "Maximum temperature", error)
+    call h5ltset_attribute_string_f(gid, "tmax", "units", "keV", error)
+
+    call h5ltset_attribute_string_f(gid, "bt_amu", "description", &
+         "Isotope mass of the beam and target species respectively", error)
+    call h5ltset_attribute_string_f(gid, "bt_amu", "units", "amu", error)
+
+    call h5ltset_attribute_string_f(gid, "fusion", "description", &
+         "Beam-Target reaction rates for the Tritium[1] and He3[2] branches of D-D nuclear reactions: fusion(energy, temp, branch)", error)
+    call h5ltset_attribute_string_f(gid, "fusion", "units", "cm^3/s", error)
+    call h5ltset_attribute_string_f(gid, "fusion", "reaction", &
+         "D + D -> [1] T(1.01 MeV) + p(3.02 MeV) (50%); [2] He3(0.82 MeV) + n(2.45 MeV) (50%)", error)
+
+    call h5gclose_f(gid, error)
+
+    deallocate(ebarr, tarr, fusion)
+
+end subroutine write_bt_D_D
+
+subroutine write_bt_D_T(id, namelist_file)
+    !+ Write Deuterium-Tritium reaction rates to a HDF5 file
+    integer(HID_T), intent(inout) :: id
+        !+ HDF5 file or group object id
+    character(len=*), intent(in)  :: namelist_file
+        !+ Namelist file that contains settings
+
+    integer :: nbranch = 1
+    real(Float64), dimension(2) :: bt_amu = [H2_amu, H3_amu]
+
+    real(Float64) :: emin
+    real(Float64) :: emax
+    integer :: nenergy
+
+    real(Float64) :: tmin
+    real(Float64) :: tmax
+    integer :: ntemp
+
+    real(Float64) :: eb
+    real(Float64) :: dlogE
+    real(Float64), dimension(:), allocatable :: ebarr
+
+    real(Float64) :: ti
+    real(Float64) :: dlogT
+    real(Float64), dimension(:), allocatable :: tarr
+
+    real(Float64), dimension(:,:,:), allocatable :: fusion
+
+    integer(HID_T) :: gid
+    integer(HSIZE_T), dimension(1) :: dim1
+    integer(HSIZE_T), dimension(3) :: dim3
+
+    integer :: ie, it, error, cnt
+    real(Float64) :: rate
+    logical :: exis
+
+    NAMELIST /D_T_rates/ nenergy, emin, emax, ntemp, tmin, tmax
+
+    nenergy = 100; emin = 1.d-3 ; emax = 4.d2
+    ntemp = 100; tmin = 1.d-3 ; tmax = 2.d1
+
+    inquire(file=namelist_file,exist=exis)
+    if(.not.exis) then
+        write(*,'(a,a)') 'WRITE_BT_D_T: Input file does not exist: ',trim(namelist_file)
+        write(*,'(a)') 'Continuing with default settings...'
+    else
+        open(13,file=namelist_file)
+        read(13,NML=D_T_rates)
+        close(13)
+    endif
+
+    allocate(ebarr(nenergy))
+    allocate(tarr(ntemp))
+    allocate(fusion(nenergy,ntemp,nbranch))
+
+    ebarr = 0.d0
+    tarr = 0.d0
+    fusion = 0.d0
+
+    dlogE = (log10(emax) - log10(emin))/(nenergy - 1)
+    do ie=1, nenergy
+        ebarr(ie) = 10.d0**(log10(emin) + (ie-1)*dlogE)
+    enddo
+
+    dlogT = (log10(tmax) - log10(tmin))/(ntemp - 1)
+    do it=1, ntemp
+        tarr(it) = 10.d0**(log10(tmin) + (it-1)*dlogT)
+    enddo
+
+    write(*,'(a)') "---- D-T reaction rates settings ----"
+    write(*,'(T2,"Emin = ",e9.2, " keV")') emin
+    write(*,'(T2,"Emax = ",e9.2, " keV")') emax
+    write(*,'(T2,"Nenergy = ", i4)') nenergy
+    write(*,'(T2,"Tmin = ",e9.2, " keV")') tmin
+    write(*,'(T2,"Tmax = ",e9.2, " keV")') tmax
+    write(*,'(T2,"Ntemp = ", i4)') ntemp
+    write(*,*) ''
+
+    cnt = 0
+    !$OMP PARALLEL DO private(ie, it, eb, ti, rate)
+    do ie=1, nenergy
+        eb = ebarr(ie)
+        do it=1, ntemp
+            ti = tarr(it)
+            call bt_maxwellian(d_t_fusion, ti, eb, bt_amu(1), bt_amu(2), rate)
+            fusion(ie,it,1) = rate
+            cnt = cnt + 1
+            WRITE(*,'(f7.2,"%",a,$)') 100*cnt/real(nenergy*ntemp),char(13)
+        enddo
+    enddo
+    !$OMP END PARALLEL DO
+
+    call h5gcreate_f(id, "D_T", gid, error)
+
+    dim1 = [1]
+    call h5ltmake_dataset_int_f(gid, "nbranch", 0, dim1, [nbranch], error)
+    call h5ltmake_dataset_int_f(gid, "nenergy", 0, dim1, [nenergy], error)
+    call h5ltmake_dataset_int_f(gid, "ntemp", 0, dim1, [ntemp], error)
+    call h5ltmake_dataset_double_f(gid, "dlogE", 0, dim1, [dlogE], error)
+    call h5ltmake_dataset_double_f(gid, "emin", 0, dim1, [emin], error)
+    call h5ltmake_dataset_double_f(gid, "emax", 0, dim1, [emax], error)
+    call h5ltmake_dataset_double_f(gid, "dlogT", 0, dim1, [dlogT], error)
+    call h5ltmake_dataset_double_f(gid, "tmin", 0, dim1, [tmin], error)
+    call h5ltmake_dataset_double_f(gid, "tmax", 0, dim1, [tmax], error)
+
+    dim1 = [2]
+    call h5ltmake_compressed_dataset_double_f(gid, "bt_amu", 1, dim1, bt_amu, error)
+    dim1 = [nenergy]
+    call h5ltmake_compressed_dataset_double_f(gid, "energy", 1, dim1, ebarr, error)
+    dim1 = [ntemp]
+    call h5ltmake_compressed_dataset_double_f(gid, "temperature", 1, dim1, tarr, error)
+    dim3 = [nenergy, ntemp, nbranch]
+    call h5ltmake_compressed_dataset_double_f(gid, "fusion", 3, dim3, fusion, error)
+
+    call h5ltset_attribute_string_f(id, "D_T", "description", &
+         "Beam-Target reaction rates for Deuterium(beam)-Tritium(target) interactions", error)
+    call h5ltset_attribute_string_f(gid, "nbranch", "description", &
+         "Number of reaction branches", error)
+    call h5ltset_attribute_string_f(gid, "nenergy", "description", &
+         "Number of energy values", error)
+    call h5ltset_attribute_string_f(gid, "ntemp", "description", &
+         "Number of target temperature values", error)
+    call h5ltset_attribute_string_f(gid, "energy", "description", &
+         "Energy values", error)
+    call h5ltset_attribute_string_f(gid, "energy", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "dlogE", "description", &
+         "Energy spacing in log-10", error)
+    call h5ltset_attribute_string_f(gid, "dlogE", "units", "log10(keV)", error)
+    call h5ltset_attribute_string_f(gid, "emin","description", &
+         "Minimum energy", error)
+    call h5ltset_attribute_string_f(gid, "emin", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "emax","description", &
+         "Maximum energy", error)
+    call h5ltset_attribute_string_f(gid, "emax", "units", "keV", error)
+
+    call h5ltset_attribute_string_f(gid, "temperature", "description", &
+         "Target temperature values", error)
+    call h5ltset_attribute_string_f(gid, "temperature", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "dlogT", "description", &
+         "Temperature spacing in log-10", error)
+    call h5ltset_attribute_string_f(gid, "dlogT", "units", "log10(keV)", error)
+    call h5ltset_attribute_string_f(gid, "tmin","description", &
+         "Minimum temperature", error)
+    call h5ltset_attribute_string_f(gid, "tmin", "units", "keV", error)
+    call h5ltset_attribute_string_f(gid, "tmax","description", &
+         "Maximum temperature", error)
+    call h5ltset_attribute_string_f(gid, "tmax", "units", "keV", error)
+
+    call h5ltset_attribute_string_f(gid, "bt_amu", "description", &
+         "Isotope mass of the beam and target species respectively", error)
+    call h5ltset_attribute_string_f(gid, "bt_amu", "units", "amu", error)
+
+    call h5ltset_attribute_string_f(gid, "fusion", "description", &
+         "Beam-Target reaction rates for D-T nuclear reactions: fusion(energy, temperature, branch)", error)
+    call h5ltset_attribute_string_f(gid, "fusion", "units", "cm^3/s", error)
+    call h5ltset_attribute_string_f(gid, "fusion", "reaction", &
+         "D + T -> He4(3.5 MeV) + n(14.1 MeV)", error)
+
+    call h5gclose_f(gid, error)
+
+    deallocate(ebarr, tarr, fusion)
+
+end subroutine write_bt_D_T
 
 subroutine print_default_namelist
     !+ Prints out the default settings as a namelist
@@ -5529,6 +6228,12 @@ subroutine print_default_namelist
     write(*,'(a)') "!Hydrogen-Impurity Cross Sections"
     write(*,'(a)') "&H_Aq_cross"
     write(*,'(a)') "q = 6,         !Impurity charge: Boron: 5, Carbon: 6, ..."
+    write(*,'(a)') "nenergy = 200, !Number of energy values"
+    write(*,'(a)') "emin = 1.0E-3, !Minimum energy [keV]"
+    write(*,'(a)') "emax = 8.0E2   !Maximum energy [keV]"
+    write(*,'(a)') "/"
+    write(*,'(a)') "!Deuterium-Deuterium Nuclear Cross Sections"
+    write(*,'(a)') "&D_D_cross"
     write(*,'(a)') "nenergy = 200, !Number of energy values"
     write(*,'(a)') "emin = 1.0E-3, !Minimum energy [keV]"
     write(*,'(a)') "emax = 8.0E2   !Maximum energy [keV]"
@@ -5561,6 +6266,15 @@ subroutine print_default_namelist
     write(*,'(a)') "ntemp = 100,   !Number of temperature values"
     write(*,'(a)') "tmin = 1.0E-3, !Minimum ion temperature [keV]"
     write(*,'(a)') "tmax = 2.0E1   !Maximum ion temperature [keV]"
+    write(*,'(a)') "/"
+    write(*,'(a)') "!Deuterium-Deuterium Nuclear Reaction Rates"
+    write(*,'(a)') "&D_D_rates"
+    write(*,'(a)') "nenergy = 100, !Number of energy values"
+    write(*,'(a)') "emin = 1.0E-3, !Minimum energy [keV]"
+    write(*,'(a)') "emax = 4.0E2,  !Maximum energy [keV]"
+    write(*,'(a)') "ntemp = 100,   !Number of temperature values"
+    write(*,'(a)') "tmin = 1.0E-3, !Minimum deuterium temperature [keV]"
+    write(*,'(a)') "tmax = 2.0E1   !Maximum deuterium temperature [keV]"
     write(*,'(a)') "/"
 
 end subroutine print_default_namelist
@@ -5640,29 +6354,30 @@ program generate_tables
     call check_compression_availability()
 
     call date_and_time (values=time_start)
- 
+
     !! Open HDF5 Interface
     call h5open_f(error)
-  
+
     !! Create tables file. Overwrites if already exists
     call h5fcreate_f(tables_file, H5F_ACC_TRUNC_F, fid, error)
-  
+
     !! Create group for cross sections
     call h5gcreate_f(fid, "cross", gid, error)
-  
+
     !! Calculate cross sections
     call date_and_time(values=time_arr)
     write(*,"(A,I2,A,I2.2,A,I2.2)") 'Cross Sections:   ',time_arr(5),':',time_arr(6),':',time_arr(7)
     call write_bb_H_H(gid, namelist_file, n_max, m_max)
     call write_bb_H_e(gid, namelist_file, n_max, m_max)
     call write_bb_H_Aq(gid, namelist_file, n_max, m_max)
-  
+    call write_bb_D_D(gid, namelist_file)
+
     !! Close cross section group
     call h5gclose_f(gid, error)
-  
+
     !! Create group for reaction rates
     call h5gcreate_f(fid, "rates", gid, error)
-    
+
     !! Calculate reaction rates
     call date_and_time(values=time_arr)
     write(*,"(A,I2,A,I2.2,A,I2.2)") 'Reaction Rates:   ',time_arr(5),':',time_arr(6),':',time_arr(7)
@@ -5670,10 +6385,11 @@ program generate_tables
     call write_bt_H_e(gid, namelist_file, n_max, m_max)
     call write_bt_H_Aq(gid, namelist_file, n_max, m_max)
     call write_einstein(gid, n_max, m_max)
-  
+    call write_bt_D_D(gid, namelist_file)
+
     !! Close reaction rates group
     call h5gclose_f(gid, error)
-  
+
     !! Add group attributes
     call h5ltset_attribute_string_f(fid, "/", "description", &
          "Atomic Cross Sections and Rates", error)
@@ -5681,11 +6397,11 @@ program generate_tables
          "Atomic Cross Sections", error)
     call h5ltset_attribute_string_f(fid, "rates", "description", &
          "Atomic Reaction Rates", error)
-  
+
     !! Close file and HDF5 interface
     call h5fclose_f(fid, error)
     call h5close_f(error)
-  
+
     write(*,'(a)') "Atomic tables written to "//trim(tables_file)
     write(*,*) ''
 

--- a/tables/atomic_tables.f90
+++ b/tables/atomic_tables.f90
@@ -6029,7 +6029,7 @@ subroutine write_bt_D_D(id, namelist_file)
     call h5ltset_attribute_string_f(gid, "bt_amu", "units", "amu", error)
 
     call h5ltset_attribute_string_f(gid, "fusion", "description", &
-         "Beam-Target reaction rates for the Tritium[1] and He3[2] branches of D-D nuclear reactions: fusion(energy, temp, branch)", error)
+         "Beam-Target reaction rates for T/He3 branches of D-D nuclear reactions: fusion(energy, temp, branch)", error)
     call h5ltset_attribute_string_f(gid, "fusion", "units", "cm^3/s", error)
     call h5ltset_attribute_string_f(gid, "fusion", "reaction", &
          "D + D -> [1] T(1.01 MeV) + p(3.02 MeV) (50%); [2] He3(0.82 MeV) + n(2.45 MeV) (50%)", error)


### PR DESCRIPTION
This PR adds the ability to calculate neutron rates. 

To use this capability you will need to recalculate the atomic tables so that the D-D nuclear rates are included and add `calc_neutron = 1` to the `[runid]_inputs.dat` file.