### PR TITLE
fix in get_version() to work with some python 3 versions

### DIFF
--- a/lib/python/fidasim/utils.py
+++ b/lib/python/fidasim/utils.py
@@ -57,7 +57,7 @@ def get_version(fidasim_dir):
 
         # git is installed if git_file is a file
         proc = subprocess.Popen('command -v git', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-        git_file = proc.communicate()[0]
+        git_file = proc.communicate()[0].decode('utf-8')
         git_file = git_file.replace('\n', '')
 
         # Check that .git folder is present and git is installed


### PR DESCRIPTION
git_file = proc.communicate()[0] changed to git_file = proc.communicate()[0].decode('utf-8')
Fix was for Python 3.4.5. Confirmed to work in 2.7, 3.4.5, and 3.5.2 now.