### PR TITLE
Reduce contention and use faster math

### DIFF
--- a/src/eigensystem.f90
+++ b/src/eigensystem.f90
@@ -556,6 +556,7 @@ contains
     integer :: en
     integer :: i, j, na, iter, l, ll, m, k
     real(double)  :: p, q, r, s, t, w, x, y, z
+    real(double)  :: r_p,r_r,r_s,r_x,r_z
 
     p=ZERO; q=ZERO; r=ZERO
     do i = 0, n-1
@@ -599,6 +600,7 @@ contains
              p = (y - x) * 0.5d0
              q = p * p + w
              z = DSQRT(DABS(q))
+             r_z = 1.0d0/z
              x = x + t
              h(en,en) = x + t
              h(na,na) = y + t
@@ -611,14 +613,15 @@ contains
                    z=p+z
                 endif
                 wr(na) = x + z
-                wr(en) = x - w / z
-                s = w - w / z
+                wr(en) = x - w * r_z
+                s = w - w * r_z
                 wi(na) = ZERO
                 wi(en) = ZERO
                 x = h(en,na)
                 r = DSQRT (x * x + z * z)
-                p = x / r
-                q = z / r
+                r_r = 1.0d0/r
+                p = x * r_r
+                q = z * r_r
                 do j = na, n-1
                    z = h(na,j)
                    h(na,j) = q * z + p * h(en,j)
@@ -663,13 +666,14 @@ contains
              z = h(m,m)
              r = x - z
              s = y - z
+             r_s = 1.0d0/s
              p = ( r * s - w ) / h(m+1,m) + h(m,m+1)
              q = h(m + 1,m + 1) - z - r - s
              r = h(m + 2,m + 1)
              s = DABS(p) + DABS(q) + DABS (r)
-             p = p / s
-             q = q / s
-             r = r / s
+             p = p * r_s
+             q = q * r_s
+             r = r * r_s
              if (m == l)  goto 12
              if (DABS(h(m,m-1)) * (DABS(q) + DABS(r)) <= XMACH_EPS * DABS(p) &
                   * (DABS(h(m-1,m-1)) + DABS(z) + DABS(h(m+1,m+1)))) then
@@ -693,23 +697,26 @@ contains
                 endif
                 x = DABS(p) + DABS(q) + DABS(r)
                 if (x == ZERO) goto 30                  !next k
-                p = p / x
-                q = q / x
-                r = r / x
+                r_x = 1.0d0/x
+                p = p * r_x
+                q = q * r_x
+                r = r * r_x
              endif
              s = DSQRT(p * p + q * q + r * r)
              if (p < ZERO) s = -s
+             r_s = 1.0d0/s
              if (k.ne.m) then
                 h(k,k-1) = -s * x
              else if (l.ne.m) then
                 h(k,k-1) = -h(k,k-1)
              endif
              p = p + s
-             x = p / s
-             y = q / s
-             z = r / s
-             q = q / p
-             r = r / p
+             r_p = 1.0d0/p
+             x = p * r_s
+             y = q * r_s
+             z = r * r_s
+             q = q * r_p
+             r = r * r_p
              do j = k, n-1                          !modify rows
                 p = h(k,j) + q * h(k+1,j)
                 if (k.ne.na) then

--- a/src/eigensystem.f90
+++ b/src/eigensystem.f90
@@ -23,9 +23,9 @@ contains
     !+are resized to have one norm close to 1.
     integer, intent(in)  :: n
         !+ Dimension of `mat`
-    real(double)         :: mat(0:n,0:n)
+    real(double)         :: mat(0:n-1,0:n-1)
         !+ `n`x`n` scaled matrix
-    real(double)         :: scal(0:n)
+    real(double)         :: scal(0:n-1)
         !+ Contains isolated eigenvalue in the positions 0-`low` and `high`-`n`-1
         !+ its other components contain the scaling factors for transforming `mat`
     integer, intent(out) :: high
@@ -136,9 +136,9 @@ contains
       !+ First nonzero row
     integer,intent(in)         :: high
       !+ Last nonzero row
-    real(double), intent(in)   ::  scal(0:n)
+    real(double), intent(in)   ::  scal(0:n-1)
       !+ Scaling data from balance
-    real(double), intent(inout):: eivec(0:n,0:n)
+    real(double), intent(inout):: eivec(0:n-1,0:n-1)
       !+ Input: n x n matrix of eigenvectors, as computed in qr2
       !+ Output: Non-normalized eigenvectors of the original matrix
 
@@ -176,11 +176,11 @@ contains
       !+First nonzero row
     integer,intent(in)   :: high
       !+Last nonzero row
-    real(double), intent(inout):: mat(0:n,0:n)
+    real(double), intent(inout):: mat(0:n-1,0:n-1)
       !+Input: `n`x`n` matrix
       !+Output: Upper Hessenberg matrix; additional information on the tranformation
       !+is stored in the lower triangle
-    integer,intent(out)  :: perm(0:n)
+    integer,intent(out)  :: perm(0:n-1)
       !+Permutation vector for elmtrans
 
     integer              :: i, j, m
@@ -228,11 +228,11 @@ contains
       !+ First nonzero row
     integer,intent(in)         :: high
       !+ Last nonzero row
-    real(double), intent(in)   :: mat(0:n,0:n)
+    real(double), intent(in)   :: mat(0:n-1,0:n-1)
       !+ `n`x`n` input matrix
-    integer,intent(in)         :: perm(0:n)
+    integer,intent(in)         :: perm(0:n-1)
       !+ Permutation data from elmhes
-    real(double),intent(out)   :: h(0:n,0:n)
+    real(double),intent(out)   :: h(0:n-1,0:n-1)
       !+ Hessenberg matrix
     integer                    :: i, j, k
     do i = 0, n-1
@@ -343,9 +343,9 @@ contains
     !+   eivec :  n x n matrix, whose columns are the eigenvectors
     integer,intent(in)         :: n
     integer,intent(in)         :: high, low
-    real(double), intent(in)   :: wr(0:n),wi(0:n)
-    real(double), intent(out)  :: eivec(0:n,0:n)
-    real(double)  :: h(0:n,0:n)
+    real(double), intent(in)   :: wr(0:n-1),wi(0:n-1)
+    real(double), intent(out)  :: eivec(0:n-1,0:n-1)
+    real(double)  :: h(0:n-1,0:n-1)
     integer :: rc
     integer :: i, j, m, k, na, l
     integer :: code, en
@@ -548,11 +548,11 @@ contains
     !+            entry is negative.
     integer,intent(in)          :: n
     integer,intent(in)          :: high, low
-    real(double) ,intent(out)   :: h(0:n,0:n)
-    real(double), intent(out)   :: wr(0:n),wi(0:n)
-    real(double), intent(out)   :: eivec(0:n,0:n)
+    real(double) ,intent(out)   :: h(0:n-1,0:n-1)
+    real(double), intent(out)   :: wr(0:n-1),wi(0:n-1)
+    real(double), intent(out)   :: eivec(0:n-1,0:n-1)
     integer,intent(out)         :: rc
-    integer,intent(out)         :: cnt(0:n)
+    integer,intent(out)         :: cnt(0:n-1)
     integer :: en
     integer :: i, j, na, iter, l, ll, m, k
     real(double)  :: p, q, r, s, t, w, x, y, z
@@ -809,15 +809,15 @@ contains
     real(double) ,intent(in),dimension(n,n)  :: matrix
     real(double) ,intent(out),dimension(n,n) :: eigvec
     real(double) ,intent(out),dimension(n)   :: eigval
-    real(double)     :: mat(0:n,0:n)
-    real(double)     :: eivec(0:n,0:n)
-    real(double)     :: valre(0:n) !real parts of eigenvalues
-    real(double)     :: valim(0:n) !imaginary parts of eigenvalues
+    real(double)     :: mat(0:n-1,0:n-1)
+    real(double)     :: eivec(0:n-1,0:n-1)
+    real(double)     :: valre(0:n-1) !real parts of eigenvalues
+    real(double)     :: valim(0:n-1) !imaginary parts of eigenvalues
     integer          :: rc             !return code
-    integer          :: cnt(0:n)   !Iteration counter
+    integer          :: cnt(0:n-1)   !Iteration counter
     integer          :: high, low
-    real(double)     :: d(0:n), scale(0:n)
-    integer          :: perm(0:n)
+    real(double)     :: d(0:n-1), scale(0:n-1)
+    integer          :: perm(0:n-1)
 
     cnt=0 ; d=0.d0
     mat(0:n-1,0:n-1)=matrix(1:n,1:n)


### PR DESCRIPTION
Reduce OMP contention by doing a bulk update of neutral densities
Explicitly calculate 1/r and reuse it multiple times. Divisions are slower than multiplication