### PR TITLE
Use blas for solving linear equations - pgf90 only

### DIFF
--- a/makefile
+++ b/makefile
@@ -63,9 +63,9 @@ ifneq ($(findstring gfortran, $(FC)),)
 	PROF_FLAGS = -pg -D_PROF
 endif
 ifneq ($(findstring pgf90, $(FC)),)
-        LFLAGS = -lm
-        COMMON_CFLAGS = -O3 -Mpreprocess -tp=haswell -D_DEF_INTR
-        DEBUG_CFLAGS = -O0 -g -Mpreprocess -traceback -D_DEF_INTR -D_DEBUG
+        LFLAGS = -lm -lblas
+        COMMON_CFLAGS = -O3 -Mpreprocess -tp=haswell -D_DEF_INTR -D_USE_BLAS
+        DEBUG_CFLAGS = -O0 -g -Mpreprocess -traceback -D_DEF_INTR -D_USE_BLAS -D_DEBUG
         OPENMP_FLAGS = -mp -D_OMP
         MPI_FLAGS = -D_MPI
         PROF_FLAGS = -pg -D_PROF

--- a/src/eigensystem.f90
+++ b/src/eigensystem.f90
@@ -946,7 +946,7 @@ contains
 
    ! first factorize a
    lu(:,:) = a(:,:)
-   call DGETRF(n,n,,lu,n,ipiv,info)
+   call DGETRF(n,n,lu,n,ipiv,info)
    if (info /= 0) stop 'sub linsolve: DGETRF failed!'
 
    x(:) = b(:)

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -4,7 +4,7 @@ module libfida
 USE H5LT !! High level HDF5 Interface
 USE HDF5 !! Base HDF5
 USE hdf5_extra !! Additional HDF5 routines
-USE eigensystem, ONLY : eigen, matinv
+USE eigensystem, ONLY : eigen, linsolve
 USE utilities
 
 implicit none
@@ -6716,7 +6716,7 @@ subroutine colrad(plasma,i_type,vn,dt,states,dens,photons)
     real(Float64) :: vnet_square    !! net velocity of neutrals squared
     real(Float64) :: eb             !! Energy of the fast neutral
 
-    real(Float64), dimension(nlevs,nlevs) :: eigvec, eigvec_inv
+    real(Float64), dimension(nlevs,nlevs) :: eigvec
     real(Float64), dimension(nlevs) :: eigval, coef
     real(Float64), dimension(nlevs) :: exp_eigval_dt
     real(Float64) :: iflux !!Initial total flux
@@ -6742,8 +6742,7 @@ subroutine colrad(plasma,i_type,vn,dt,states,dens,photons)
     call get_rate_matrix(plasma, i_type, eb, matrix)
 
     call eigen(nlevs,matrix, eigvec, eigval)
-    call matinv(eigvec, eigvec_inv)
-    coef = matmul(eigvec_inv, states)!coeffs determined from states at t=0
+    call linsolve(eigvec,states,coef) !coeffs determined from states at t=0
     exp_eigval_dt = exp(eigval*dt)   ! to improve speed (used twice)
     do n=1,nlevs
         if(eigval(n).eq.0.0) eigval(n)=eigval(n)+1 !protect against dividing by zero


### PR DESCRIPTION
The pgf90 compiler does a very poor job optimizing matinv,
and BLAS has an efficient implementation for solving linear equations.

pgf90 comes pre-packaged with BLAS libraries, so use the BLAS version in pgf90.

Avoid using BLAS with gcc for now. The benefit is much smaller, and would introduce an additional external dependency.