### PR TITLE
Replace OpenCoArrays with pure MPI

### DIFF
--- a/deps/makefile
+++ b/deps/makefile
@@ -10,9 +10,6 @@ export OMPI_CC = $(CC)
 export OMPI_CXX = $(CXX)
 
 TARGETS = hdf5
-ifeq ($(USE_MPI),y)
-    TARGETS := $(TARGETS) opencoarrays
-endif
 
 all: $(TARGETS)
 
@@ -26,6 +23,7 @@ hdf5:
 	-rm -rf hdf5-1.8.16
 	@printf "HDF5 build complete\n\n"
 
+# Note: Not used anymore, left only for historical reasons
 opencoarrays:
 	@printf "\nBuilding OpenCoarrays...\n"
 	tar -zvxf $(DEPS_DIR)/OpenCoarrays-1.9.3.tar.gz >> $(OPENCOARRAYS_LOG) 2>&1

--- a/makefile
+++ b/makefile
@@ -63,7 +63,7 @@ ifneq ($(findstring gfortran, $(FC)),)
 	PROF_FLAGS = -pg -D_PROF
 endif
 ifneq ($(findstring pgf90, $(FC)),)
-        LFLAGS = -lm -lblas
+        LFLAGS = -lm -llapack -lblas
         COMMON_CFLAGS = -O3 -Mpreprocess -tp=haswell -D_DEF_INTR -D_USE_BLAS
         DEBUG_CFLAGS = -O0 -g -Mpreprocess -traceback -D_DEF_INTR -D_USE_BLAS -D_DEBUG
         OPENMP_FLAGS = -mp -D_OMP

--- a/makefile
+++ b/makefile
@@ -100,7 +100,7 @@ endif
 
 ifeq ($(USE_MPI),y)
 	USE_OPENMP = n
-	MPI_FC = caf
+	MPI_FC = mpif90
 	CFLAGS = $(COMMON_CFLAGS) $(UFLAGS) $(MPI_FLAGS)
 endif
 
@@ -134,17 +134,6 @@ fidasim: deps src tables
 
 .PHONY: deps
 deps:
-ifneq ($(findstring pgf90, $(FC)),)
-ifeq ($(USE_MPI),y)
-	$(error MPI not supported with pgfortran)
-endif
-endif
-ifneq ($(findstring ifort, $(FC)),)
-ifeq ($(USE_MPI),y)
-	$(error MPI not supported with ifort)
-endif
-endif
-
 	@cd $(DEPS_DIR); make
 
 .PHONY: src

--- a/src/fidampi.f90
+++ b/src/fidampi.f90
@@ -1,0 +1,158 @@
+module fidampi
+
+  integer, parameter, private   :: Float64 = 8
+  integer, private :: num_ranks, my_rank
+
+  interface fidampi_sum
+     module procedure fidampi_sum_d0, fidampi_sum_d1, fidampi_sum_d2, &
+                      fidampi_sum_d3, fidampi_sum_d4, fidampi_sum_d5,&
+                      fidampi_sum_i0, fidampi_sum_i1, fidampi_sum_i2
+  end interface
+
+contains
+
+  recursive subroutine fidampi_sum_d0(A)
+    use mpi
+    implicit none
+
+    real(Float64), intent(inout) :: A
+
+    integer :: sizeA,ierr
+
+    sizeA = 1
+
+    if (num_ranks>1) then
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+    endif ! else nothing to do
+
+  end subroutine
+
+  recursive subroutine fidampi_sum_d1(A)
+    use mpi
+    implicit none  
+
+    real(Float64), dimension(:), intent(inout) :: A
+    
+    integer :: sizeA,ierr
+
+    sizeA = size(A,1)
+
+    if (num_ranks>1) then
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+    endif ! else nothing to do
+
+  end subroutine
+
+  recursive subroutine fidampi_sum_d2(A)
+    use mpi
+    implicit none
+
+    real(Float64), dimension(:,:), intent(inout) :: A
+
+    integer :: sizeA,ierr
+
+    sizeA = size(A,1)*size(A,2)
+
+    if (num_ranks>1) then
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+    endif ! else nothing to do
+
+  end subroutine
+
+  recursive subroutine fidampi_sum_d3(A)
+    use mpi
+    implicit none
+
+    real(Float64), dimension(:,:,:), intent(inout) :: A
+
+    integer :: sizeA,ierr
+
+    sizeA = size(A,1)*size(A,2)*size(A,3)
+
+    if (num_ranks>1) then
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+    endif ! else nothing to do
+
+  end subroutine
+
+  recursive subroutine fidampi_sum_d4(A)
+    use mpi
+    implicit none
+
+    real(Float64), dimension(:,:,:,:), intent(inout) :: A
+
+    integer :: sizeA,ierr
+
+    sizeA = size(A,1)*size(A,2)*size(A,3)*size(A,4)
+
+    if (num_ranks>1) then
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+    endif ! else nothing to do
+
+  end subroutine
+
+  recursive subroutine fidampi_sum_d5(A)
+    use mpi
+    implicit none
+
+    real(Float64), dimension(:,:,:,:,:), intent(inout) :: A
+
+    integer :: sizeA,ierr
+
+    sizeA = size(A,1)*size(A,2)*size(A,3)*size(A,4)*size(A,5)
+
+    if (num_ranks>1) then
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+    endif ! else nothing to do
+
+  end subroutine
+
+  recursive subroutine fidampi_sum_i0(A)
+    use mpi
+    implicit none
+
+    integer, intent(inout) :: A
+
+    integer :: sizeA,ierr
+
+    sizeA = 1
+
+    if (num_ranks>1) then
+       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,ierr)
+    endif ! else nothing to do
+
+  end subroutine
+
+  recursive subroutine fidampi_sum_i1(A)
+    use mpi
+    implicit none
+
+    integer, dimension(:), intent(inout) :: A
+
+    integer :: sizeA,ierr
+
+    sizeA = size(A,1)
+
+    if (num_ranks>1) then
+       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,ierr)
+    endif ! else nothing to do
+
+  end subroutine
+
+  recursive subroutine fidampi_sum_i2(A)
+    use mpi
+    implicit none
+
+    integer, dimension(:,:), intent(inout) :: A
+
+    integer :: sizeA,ierr
+
+    sizeA = size(A,1)*size(A,2)
+
+    if (num_ranks>1) then
+       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,ierr)
+    endif ! else nothing to do
+
+  end subroutine
+
+end module

--- a/src/fidampi.f90
+++ b/src/fidampi.f90
@@ -42,7 +42,7 @@ contains
   end function
 
   recursive function fidampi_num_ranks() result (n)
-    n = num_rank
+    n = num_ranks
   end function
 
   recursive subroutine fidampi_sum_d0(A)
@@ -56,7 +56,7 @@ contains
     sizeA = 1
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
+       call MPI_Allreduce(MPI_IN_PLACE,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -72,7 +72,7 @@ contains
     sizeA = size(A,1)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
+       call MPI_Allreduce(MPI_IN_PLACE,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -88,7 +88,7 @@ contains
     sizeA = size(A,1)*size(A,2)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
+       call MPI_Allreduce(MPI_IN_PLACE,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -104,7 +104,7 @@ contains
     sizeA = size(A,1)*size(A,2)*size(A,3)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
+       call MPI_Allreduce(MPI_IN_PLACE,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -120,7 +120,7 @@ contains
     sizeA = size(A,1)*size(A,2)*size(A,3)*size(A,4)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
+       call MPI_Allreduce(MPI_IN_PLACE,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -136,7 +136,7 @@ contains
     sizeA = size(A,1)*size(A,2)*size(A,3)*size(A,4)*size(A,5)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
+       call MPI_Allreduce(MPI_IN_PLACE,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -152,7 +152,7 @@ contains
     sizeA = 1
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,MPI_COMM_WORLD,ierr)
+       call MPI_Allreduce(MPI_IN_PLACE,A,sizeA,MPI_INTEGER,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -168,7 +168,7 @@ contains
     sizeA = size(A,1)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,MPI_COMM_WORLD,ierr)
+       call MPI_Allreduce(MPI_IN_PLACE,A,sizeA,MPI_INTEGER,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -184,7 +184,7 @@ contains
     sizeA = size(A,1)*size(A,2)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,MPI_COMM_WORLD,ierr)
+       call MPI_Allreduce(MPI_IN_PLACE,A,sizeA,MPI_INTEGER,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine

--- a/src/fidampi.f90
+++ b/src/fidampi.f90
@@ -36,6 +36,16 @@ contains
 
   end subroutine
 
+  subroutine fidampi_clenup()
+    use mpi
+    implicit none
+   
+    integer :: ierr
+
+    call MPI_BARRIER(MPI_COMM_WORLD,ierr)
+
+    call MPI_FINALIZE(ierr)
+  end subroutine
 
   recursive function fidampi_my_rank() result (n)
     n = my_rank

--- a/src/fidampi.f90
+++ b/src/fidampi.f90
@@ -11,6 +11,40 @@ module fidampi
 
 contains
 
+  subroutine fidampi_init()
+    use mpi
+    implicit none
+
+    integer :: provided, ierr
+
+#ifdef _OMP
+    call MPI_INIT_THREAD(MPI_THREAD_FUNNELED,provided,ierr)
+#else
+    call MPI_INIT(ierr)
+#endif
+
+   num_ranks = 1
+   my_rank = 0
+   if (ierr/=0) then
+     write(*,*) "MPI initialization failed, assuming single MPI process"
+   else
+     call MPI_COMM_SIZE(MPI_COMM_WORLD,num_ranks,ierr)
+     if (num_ranks>1) then
+       call MPI_COMM_RANK(MPI_COMM_WORLD,my_rank,ierr)
+     endif
+   endif
+
+  end subroutine
+
+
+  recursive function fidampi_my_rank() result (n)
+    n = my_rank
+  end function
+
+  recursive function fidampi_num_ranks() result (n)
+    n = num_rank
+  end function
+
   recursive subroutine fidampi_sum_d0(A)
     use mpi
     implicit none
@@ -22,7 +56,7 @@ contains
     sizeA = 1
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -38,7 +72,7 @@ contains
     sizeA = size(A,1)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -54,7 +88,7 @@ contains
     sizeA = size(A,1)*size(A,2)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -70,7 +104,7 @@ contains
     sizeA = size(A,1)*size(A,2)*size(A,3)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -86,7 +120,7 @@ contains
     sizeA = size(A,1)*size(A,2)*size(A,3)*size(A,4)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -102,7 +136,7 @@ contains
     sizeA = size(A,1)*size(A,2)*size(A,3)*size(A,4)*size(A,5)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,ierr)
+       call MPI_Allreduce(A,A,sizeA,MPI_DOUBLE,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -118,7 +152,7 @@ contains
     sizeA = 1
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,ierr)
+       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -134,7 +168,7 @@ contains
     sizeA = size(A,1)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,ierr)
+       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine
@@ -150,7 +184,7 @@ contains
     sizeA = size(A,1)*size(A,2)
 
     if (num_ranks>1) then
-       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,ierr)
+       call MPI_Allreduce(A,A,sizeA,MPI_INTEGER,MPI_Sum,MPI_COMM_WORLD,ierr)
     endif ! else nothing to do
 
   end subroutine

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -6,6 +6,9 @@ USE HDF5 !! Base HDF5
 USE hdf5_extra !! Additional HDF5 routines
 USE eigensystem, ONLY : eigen, linsolve
 USE utilities
+#ifdef _MPI
+USE fidampi
+#endif
 
 implicit none
 
@@ -2453,8 +2456,8 @@ subroutine read_npa
             enddo
             !$OMP END PARALLEL DO
 #ifdef _MPI
-            call co_sum(eff_rds)
-            call co_sum(probs)
+            call fidampi_sum(eff_rds)
+            call fidampi_sum(probs)
 #endif
             do ic = 1, beam_grid%ngrid
                 if(probs(ic).gt.0.0) then
@@ -3499,7 +3502,7 @@ subroutine write_birth_profile
     npart = birth%cnt-1
 
 #ifdef _MPI
-    call co_sum(npart)
+    call fidampi_sum(npart)
 #endif
 
     allocate(ri(3,npart))
@@ -3546,10 +3549,10 @@ subroutine write_birth_profile
 
     do_write = .True.
 #ifdef _MPI
-    call co_sum(ri)
-    call co_sum(vi)
-    call co_sum(inds)
-    call co_sum(neut_types)
+    call fidampi_sum(ri)
+    call fidampi_sum(vi)
+    call fidampi_sum(inds)
+    call fidampi_sum(neut_types)
     if(this_image().ne.1) do_write = .False.
 #endif
 
@@ -3728,8 +3731,8 @@ subroutine write_npa
     endif
 
 #ifdef _MPI
-    call co_sum(dcount)
-    call co_sum(npart)
+    call fidampi_sum(dcount)
+    call fidampi_sum(npart)
 #endif
 
     c = 0
@@ -3766,12 +3769,12 @@ subroutine write_npa
             c = c + 1
         enddo
 #ifdef _MPI
-        call co_sum(ri)
-        call co_sum(rf)
-        call co_sum(weight)
-        call co_sum(energy)
-        call co_sum(pitch)
-        call co_sum(det)
+        call fidampi_sum(ri)
+        call fidampi_sum(rf)
+        call fidampi_sum(weight)
+        call fidampi_sum(energy)
+        call fidampi_sum(pitch)
+        call fidampi_sum(det)
 #endif
     endif
 
@@ -3879,8 +3882,8 @@ subroutine write_npa
     endif
 
 #ifdef _MPI
-    call co_sum(dcount)
-    call co_sum(npart)
+    call fidampi_sum(dcount)
+    call fidampi_sum(npart)
 #endif
 
     c = 0
@@ -3917,12 +3920,12 @@ subroutine write_npa
             c = c + 1
         enddo
 #ifdef _MPI
-        call co_sum(ri)
-        call co_sum(rf)
-        call co_sum(weight)
-        call co_sum(energy)
-        call co_sum(pitch)
-        call co_sum(det)
+        call fidampi_sum(ri)
+        call fidampi_sum(rf)
+        call fidampi_sum(weight)
+        call fidampi_sum(energy)
+        call fidampi_sum(pitch)
+        call fidampi_sum(det)
 #endif
     endif
 
@@ -7726,18 +7729,18 @@ subroutine ndmc
 
 #ifdef _MPI
     !! Combine beam neutrals
-    call co_sum(neut%full)
-    call co_sum(neut%half)
-    call co_sum(neut%third)
-    call co_sum(nbi_outside)
+    call fidampi_sum(neut%full)
+    call fidampi_sum(neut%half)
+    call fidampi_sum(neut%third)
+    call fidampi_sum(nbi_outside)
     if(inputs%calc_birth.ge.1) then
-        call co_sum(birth%dens)
+        call fidampi_sum(birth%dens)
     endif
     !! Combine spectra
     if(inputs%calc_nbi.ge.1) then
-        call co_sum(spec%full)
-        call co_sum(spec%half)
-        call co_sum(spec%third)
+        call fidampi_sum(spec%full)
+        call fidampi_sum(spec%half)
+        call fidampi_sum(spec%third)
     endif
 #endif
 
@@ -7825,7 +7828,7 @@ subroutine bremsstrahlung
 
 #ifdef _MPI
     !! Combine Brems
-    call co_sum(spec%brems)
+    call fidampi_sum(spec%brems)
 #endif
 
     deallocate(lambda_arr,brems)
@@ -7926,11 +7929,11 @@ subroutine dcx
 
 #ifdef _MPI
     !! Combine densities
-    call co_sum(neut%dcx)
+    call fidampi_sum(neut%dcx)
     if(inputs%calc_dcx.ge.1) then
-        call co_sum(spec%dcx)
+        call fidampi_sum(spec%dcx)
     endif
-    call co_sum(halo_iter_dens(dcx_type))
+    call fidampi_sum(halo_iter_dens(dcx_type))
 #endif
 
 end subroutine dcx
@@ -8062,8 +8065,8 @@ subroutine halo
 
 #ifdef _MPI
         !! Combine densities
-        call co_sum(dens_cur)
-        call co_sum(halo_iter_dens(cur_type))
+        call fidampi_sum(dens_cur)
+        call fidampi_sum(halo_iter_dens(cur_type))
 #endif
 
         if(halo_iter_dens(cur_type)/halo_iter_dens(prev_type).gt.1.0) then
@@ -8085,7 +8088,7 @@ subroutine halo
 #ifdef _MPI
     !! Combine Spectra
     if(inputs%calc_halo.ge.1) then
-        call co_sum(spec%halo)
+        call fidampi_sum(spec%halo)
     endif
 #endif
 
@@ -8152,9 +8155,9 @@ subroutine nbi_spec
 
 #ifdef _MPI
     !! Combine Spectra
-    call co_sum(spec%full)
-    call co_sum(spec%half)
-    call co_sum(spec%third)
+    call fidampi_sum(spec%full)
+    call fidampi_sum(spec%half)
+    call fidampi_sum(spec%third)
 #endif
 
 end subroutine nbi_spec
@@ -8199,7 +8202,7 @@ subroutine dcx_spec
 
 #ifdef _MPI
     !! Combine Spectra
-    call co_sum(spec%dcx)
+    call fidampi_sum(spec%dcx)
 #endif
 
 end subroutine dcx_spec
@@ -8244,7 +8247,7 @@ subroutine halo_spec
 
 #ifdef _MPI
     !! Combine Spectra
-    call co_sum(spec%halo)
+    call fidampi_sum(spec%halo)
 #endif
 
 end subroutine halo_spec
@@ -8278,7 +8281,7 @@ subroutine cold_spec
 
 #ifdef _MPI
     !! Combine Spectra
-    call co_sum(spec%cold)
+    call fidampi_sum(spec%cold)
 #endif
 
 end subroutine cold_spec
@@ -8387,7 +8390,7 @@ subroutine fida_f
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(spec%fida)
+    call fidampi_sum(spec%fida)
 #endif
 
 end subroutine fida_f
@@ -8491,7 +8494,7 @@ subroutine pfida_f
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(spec%pfida)
+    call fidampi_sum(spec%pfida)
 #endif
 
 end subroutine pfida_f
@@ -8584,7 +8587,7 @@ subroutine fida_mc
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(spec%fida)
+    call fidampi_sum(spec%fida)
 #endif
 
 end subroutine fida_mc
@@ -8677,7 +8680,7 @@ subroutine pfida_mc
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(spec%pfida)
+    call fidampi_sum(spec%pfida)
 #endif
 
 end subroutine pfida_mc
@@ -8791,8 +8794,8 @@ subroutine npa_f
 
     npart = npa%npart
 #ifdef _MPI
-    call co_sum(npart)
-    call co_sum(npa%flux)
+    call fidampi_sum(npart)
+    call fidampi_sum(npa%flux)
 #endif
 
     if(inputs%verbose.ge.1) then
@@ -8905,8 +8908,8 @@ subroutine pnpa_f
 
     npart = pnpa%npart
 #ifdef _MPI
-    call co_sum(npart)
-    call co_sum(pnpa%flux)
+    call fidampi_sum(npart)
+    call fidampi_sum(pnpa%flux)
 #endif
 
     if(inputs%verbose.ge.1) then
@@ -9050,8 +9053,8 @@ subroutine npa_mc
 
     npart = npa%npart
 #ifdef _MPI
-    call co_sum(npart)
-    call co_sum(npa%flux)
+    call fidampi_sum(npart)
+    call fidampi_sum(npa%flux)
 #endif
 
     if(inputs%verbose.ge.1) then
@@ -9197,8 +9200,8 @@ subroutine pnpa_mc
 
     npart = pnpa%npart
 #ifdef _MPI
-    call co_sum(npart)
-    call co_sum(pnpa%flux)
+    call fidampi_sum(npart)
+    call fidampi_sum(pnpa%flux)
 #endif
 
     if(inputs%verbose.ge.1) then
@@ -9270,8 +9273,8 @@ subroutine neutron_f
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(neutron%rate)
-    call co_sum(neutron%weight)
+    call fidampi_sum(neutron%rate)
+    call fidampi_sum(neutron%weight)
 #endif
 
     if(inputs%verbose.ge.1) then
@@ -9370,7 +9373,7 @@ subroutine neutron_mc
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(neutron%rate)
+    call fidampi_sum(neutron%rate)
 #endif
 
     if(inputs%verbose.ge.1) then
@@ -9556,8 +9559,8 @@ subroutine fida_weights_mc
     endif
 
 #ifdef _MPI
-    call co_sum(fweight%weight)
-    call co_sum(fweight%mean_f)
+    call fidampi_sum(fweight%weight)
+    call fidampi_sum(fweight%mean_f)
     if(this_image().eq.1) call write_fida_weights()
 #else
     call write_fida_weights()
@@ -9782,8 +9785,8 @@ subroutine fida_weights_los
     endif
 
 #ifdef _MPI
-    call co_sum(fweight%weight)
-    call co_sum(fweight%mean_f)
+    call fidampi_sum(fweight%weight)
+    call fidampi_sum(fweight%mean_f)
     if(this_image().eq.1) call write_fida_weights()
 #else
     call write_fida_weights()
@@ -9931,11 +9934,11 @@ subroutine npa_weights
     enddo loop_over_channels
 
 #ifdef _MPI
-    call co_sum(nweight%weight)
-    call co_sum(nweight%flux)
-    call co_sum(nweight%cx)
-    call co_sum(nweight%attenuation)
-    call co_sum(nweight%emissivity)
+    call fidampi_sum(nweight%weight)
+    call fidampi_sum(nweight%flux)
+    call fidampi_sum(nweight%cx)
+    call fidampi_sum(nweight%attenuation)
+    call fidampi_sum(nweight%emissivity)
 #endif
 
     do ichan=1,npa_chords%nchan

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -10012,7 +10012,7 @@ program fidasim
     narg = command_argument_count()
     if(narg.eq.0) then
 #ifdef _MPI
-        if(fidampi_my_rank().eq.0) write(*,'(a)') "usage: cafrun -np [num_processes] ./fidasim namelist_file"
+        if(fidampi_my_rank().eq.0) write(*,'(a)') "usage: mpirun -np [num_processes] ./fidasim namelist_file"
 #else
         write(*,'(a)') "usage: ./fidasim namelist_file [num_threads]"
 #endif

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -3583,7 +3583,7 @@ subroutine write_birth_profile
     c = 0
 #ifdef _MPI
     my_rank = fidampi_my_rank()
-    allocate(npart_image(fidampi_num_ranks()))
+    allocate(npart_image(0:fidampi_num_ranks()-1))
     npart_image(:) = 0
     npart_image(my_rank) = birth%cnt - 1
     call fidampi_sum(npart_image)
@@ -3776,7 +3776,7 @@ subroutine write_npa
     integer, dimension(:), allocatable :: npart_image
 
     my_rank = fidampi_my_rank()
-    allocate(npart_image(fidampi_num_ranks()))
+    allocate(npart_image(0:fidampi_num_ranks()-1))
 #endif
 
 #ifdef _MPI

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -10490,6 +10490,10 @@ program fidasim
         if(inputs%verbose.ge.1) write(*,'(30X,a)') ''
     endif
 
+#ifdef _MPI
+    call fidampi_clenup
+#endif
+
     if(inputs%verbose.ge.1) then
         write(*,*) 'END: hour:minute:second ', time(time_start)
     endif

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -3818,7 +3818,6 @@ subroutine write_npa
     do i=0,my_rank-1
         c = c +  npart_image(i)
     enddo
-    deallocate(npart_image)
 #endif
     start_index = 1 + c
     end_index = npa%npart + c

--- a/src/makefile
+++ b/src/makefile
@@ -1,10 +1,20 @@
 SHELL = /bin/bash
 
-$(FIDASIM_DIR)/fidasim: fidasim.o eigensystem.o utilities.o hdf5_extra.o
+FIDADEPS=fidasim.o eigensystem.o utilities.o hdf5_extra.o
+
+ifeq ($(USE_MPI),y)
+   FIDADEPS := fidampi.o $(FIDADEPS)
+endif
+
+
+$(FIDASIM_DIR)/fidasim: $(FIDADEPS)
 	$(MPI_FC) $(CFLAGS) $^ -o $@ $(LFLAGS)
 
-fidasim.o: fidasim.f90 eigensystem.mod utilities.mod hdf5_extra.mod
-	$(MPI_FC) $(CFLAGS) -c $(IFLAGS)  $<
+fidampi.o: fidampi.f90
+	$(MPI_FC) $(CFLAGS) -c $(IFLAGS) $< 
+
+fidasim.o: fidasim.f90 eigensystem.mod utilities.mod hdf5_extra.mod fidampi.f90 fidampi.f90
+	$(MPI_FC) $(CFLAGS) -c $(IFLAGS) $< 
 
 eigensystem.mod eigensystem.o: eigensystem.f90
 	$(MPI_FC) $(CFLAGS) -c $(IFLAGS) $<

--- a/src/utilities.f90
+++ b/src/utilities.f90
@@ -216,6 +216,10 @@ function rng_seed() result (seed)
 end function rng_seed
 
 subroutine rng_init(self, seed)
+#ifdef _MPI
+    use fidampi
+#endif
+
     !+ Procedure to initialize a random number generator with a seed.
     !+ If seed is negative then random seed is used
     type(rng_type), intent(inout) :: self
@@ -229,7 +233,7 @@ subroutine rng_init(self, seed)
         s = rng_seed()
     else
 #ifdef _MPI
-        s = seed + this_image() - 1
+        s = seed + fidampi_my_rank()
 #else
         s = seed
 #endif

--- a/tables/atomic_tables.f90
+++ b/tables/atomic_tables.f90
@@ -21,6 +21,9 @@ module atomic_tables
 use H5LT
 use HDF5
 use hdf5_extra
+#ifdef _MPI
+use fidampi
+#endif
 
 IMPLICIT NONE
 
@@ -4698,10 +4701,10 @@ subroutine write_bb_H_H(id, namelist_file, n_max, m_max)
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(ebarr)
-    call co_sum(cx)
-    call co_sum(excit)
-    call co_sum(ioniz)
+    call fidampi_sum(ebarr)
+    call fidampi_sum(cx)
+    call fidampi_sum(excit)
+    call fidampi_sum(ioniz)
 #endif
 
     if(verbose) then
@@ -4846,9 +4849,9 @@ subroutine write_bb_H_e(id, namelist_file, n_max, m_max)
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(ebarr)
-    call co_sum(excit)
-    call co_sum(ioniz)
+    call fidampi_sum(ebarr)
+    call fidampi_sum(excit)
+    call fidampi_sum(ioniz)
 #endif
 
     if(verbose) then
@@ -5005,10 +5008,10 @@ subroutine write_bb_H_Aq(id, namelist_file, n_max, m_max)
     enddo
 
 #ifdef _MPI
-    call co_sum(ebarr)
-    call co_sum(cx)
-    call co_sum(excit)
-    call co_sum(ioniz)
+    call fidampi_sum(ebarr)
+    call fidampi_sum(cx)
+    call fidampi_sum(excit)
+    call fidampi_sum(ioniz)
 #endif
 
     if(verbose) then
@@ -5145,8 +5148,8 @@ subroutine write_bb_D_D(id, namelist_file)
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(ebarr)
-    call co_sum(fusion)
+    call fidampi_sum(ebarr)
+    call fidampi_sum(fusion)
 #endif
 
     if(verbose) then
@@ -5262,8 +5265,8 @@ subroutine write_bb_D_T(id, namelist_file)
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(ebarr)
-    call co_sum(fusion)
+    call fidampi_sum(ebarr)
+    call fidampi_sum(fusion)
 #endif
 
     if(verbose) then
@@ -5444,11 +5447,11 @@ subroutine write_bt_H_H(id, namelist_file, n_max, m_max)
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(ebarr)
-    call co_sum(tarr)
-    call co_sum(cx)
-    call co_sum(excit)
-    call co_sum(ioniz)
+    call fidampi_sum(ebarr)
+    call fidampi_sum(tarr)
+    call fidampi_sum(cx)
+    call fidampi_sum(excit)
+    call fidampi_sum(ioniz)
 #endif
 
     if(verbose) then
@@ -5667,10 +5670,10 @@ subroutine write_bt_H_e(id, namelist_file, n_max, m_max)
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(ebarr)
-    call co_sum(tarr)
-    call co_sum(excit)
-    call co_sum(ioniz)
+    call fidampi_sum(ebarr)
+    call fidampi_sum(tarr)
+    call fidampi_sum(excit)
+    call fidampi_sum(ioniz)
 #endif
 
     if(verbose) then
@@ -5909,11 +5912,11 @@ subroutine write_bt_H_Aq(id, namelist_file, n_max, m_max)
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(ebarr)
-    call co_sum(tarr)
-    call co_sum(cx)
-    call co_sum(excit)
-    call co_sum(ioniz)
+    call fidampi_sum(ebarr)
+    call fidampi_sum(tarr)
+    call fidampi_sum(cx)
+    call fidampi_sum(excit)
+    call fidampi_sum(ioniz)
 #endif
 
     if(verbose) then
@@ -6108,9 +6111,9 @@ subroutine write_bt_D_D(id, namelist_file)
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(ebarr)
-    call co_sum(tarr)
-    call co_sum(fusion)
+    call fidampi_sum(ebarr)
+    call fidampi_sum(tarr)
+    call fidampi_sum(fusion)
 #endif
 
     if(verbose) then
@@ -6282,9 +6285,9 @@ subroutine write_bt_D_T(id, namelist_file)
     !$OMP END PARALLEL DO
 
 #ifdef _MPI
-    call co_sum(ebarr)
-    call co_sum(tarr)
-    call co_sum(fusion)
+    call fidampi_sum(ebarr)
+    call fidampi_sum(tarr)
+    call fidampi_sum(fusion)
 #endif
 
     if(verbose) then
@@ -6502,12 +6505,12 @@ program generate_tables
 #endif
 
 #ifdef _MPI
-    istart = this_image()
-    istep = num_images()
-    if(this_image().ne.1) verbose = .False.
+    istart = fidampi_my_rank()+1
+    istep = fidampi_num_ranks()
+    if(fidampi_my_rank().ne.0) verbose = .False.
     if(verbose) then
         write(*,'(a)') "---- MPI settings ----"
-        write(*,'(T2,"Number of processes: ",i2)') num_images()
+        write(*,'(T2,"Number of processes: ",i2)') fidampi_num_ranks()
         write(*,*) ''
     endif
 #endif

--- a/tables/makefile
+++ b/tables/makefile
@@ -3,15 +3,22 @@ SHELL = /bin/bash
 EX = $(TABLES_DIR)/generate_tables
 
 ifeq ($(USE_MPI),y)
-	EX := cafrun -np 1 $(EX)
+	EX := mpirun -np 1 $(EX)
+endif
+
+TBDEPS=$(SRC_DIR)/hdf5_extra.o
+TBDEPMODS=$(SRC_DIR)/hdf5_extra.mod
+ifeq ($(USE_MPI),y)
+  TBDEPS    := $(SRC_DIR)/fidampi.o $(TBDEPS)
+  TBDEPMODS := $(SRC_DIR)/fidampi.mod $(TBDEPMODS)
 endif
 
 all: generate_tables table_settings
 
-generate_tables: atomic_tables.o $(SRC_DIR)/hdf5_extra.o
+generate_tables: atomic_tables.o $(TBDEPS)
 	$(MPI_FC) $(CFLAGS) $^ -o $@ $(LFLAGS)
 
-atomic_tables.o: atomic_tables.f90 $(SRC_DIR)/hdf5_extra.mod
+atomic_tables.o: atomic_tables.f90 $(TBDEPMODS)
 	$(MPI_FC) $(CFLAGS) -c $< $(IFLAGS)
 
 .PHONY: table_settings


### PR DESCRIPTION
Since basically only co_sum was used out of the OpenCoArrays library,
I re-implemented it using pure MPI, which is much widely supported.
A dedicated fidempi module has been created to incapsulate all of the MPI details.

Some minor refactoring of the code was needed to account for the other differences.

The code has been verified to work with both gcc7 and ifort2017.
