### PR TITLE
Fix loop indexing bug

### DIFF
--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -11952,7 +11952,7 @@ subroutine fida_weights_los
                     call bb_cx_rates(tdens,vnbi_t,vi,rates)
                     states = states + rates
                     do is=1,n_thermal
-                        call bt_cx_rates(plasma, dcxdens + halodens, thermal_mass(i), vi, rates)
+                        call bt_cx_rates(plasma, dcxdens + halodens, thermal_mass(is), vi, rates)
                         states = states + rates*plasma%deni(is)/sum(plasma%deni)
                     enddo
 


### PR DESCRIPTION
Typo of `i` instead of `is` for ion species loop lead to problems b/c `i` was being used as an outer loop index, so `thermal_mass` got read out-of-bounds, resulting in nonsense values for the ion velocity in `fida_weights_los.`