### PR TITLE
Prefida ashape bug fix 

### DIFF
--- a/lib/python/fidasim/preprocessing.py
+++ b/lib/python/fidasim/preprocessing.py
@@ -420,9 +420,10 @@ def check_beam(inputs, nbi):
         err = True
 
     if nbi['naperture'] > 0:
-        if nbi['ashape'] not in [1, 2]:
-            error('Invalid aperture shape. Expected 1 (rectangular) or 2 (circular)')
-            err = True
+        for aper in nbi['ashape']:
+            if aper not in [1, 2]:
+                error('Invalid aperture shape. Expected 1 (rectangular) or 2 (circular)')
+                err = True
 
         w = nbi['awidy'] < 0
         nw = len(nbi['awidy'][w])


### PR DESCRIPTION
Error in prefida due to case of nbi['naperture'] > 1. If there is more than one aperture then prefida attempts to compare the array of ashape values to integer values.
Fixed by looping over nbi['ashape'] to compare each aperture shape value individually.