### PR TITLE
Srh/output res

### DIFF
--- a/lib/idl/check_inputs.pro
+++ b/lib/idl/check_inputs.pro
@@ -108,6 +108,7 @@ PRO check_inputs, inputs
                                   'seed', -1, $
                                   'stark_components', 0, $
                                   'neutrals_file',neutrals_file)
+    if (total(tag_names(inputs) EQ 'OUTPUT_NEUTRAL_RESERVOIR') EQ 0) then inputs=create_struct(inputs,'output_neutral_reservoir',1)
 
     GET_OUT:
     if err_status ne 0 then begin

--- a/lib/idl/write_namelist.pro
+++ b/lib/idl/write_namelist.pro
@@ -52,6 +52,7 @@ PRO write_namelist, filename, inputs
     printf,55,f='("seed = ",i9,  "    !! RNG Seed. If seed is negative a random seed is used")',inputs.seed
     printf,55,f='("flr = ",i2,"    !! Turn on Finite Larmor Radius effects")',inputs.flr
     printf,55,f='("load_neutrals = ",i2,"    !! Load neutrals from neutrals file")',inputs.load_neutrals
+    printf,55,f='("output_neutral_reservoir = ",i2,"    !! Output neutral reservoir to neutrals file")',inputs.output_neutral_reservoir
     printf,55,"neutrals_file = '" + inputs.neutrals_file +"'    !! File containing the neutral density"
     printf,55,f='("stark_components = ",i2 , "    !! Output stark components")',inputs.stark_components
     printf,55,f='("verbose = ",i2,"    !! Verbose")',inputs.verbose

--- a/lib/python/fidasim/preprocessing.py
+++ b/lib/python/fidasim/preprocessing.py
@@ -231,6 +231,7 @@ def check_inputs(inputs, use_abs_path=True):
     inputs['geometry_file'] = geometry_file
     inputs['distribution_file'] = distribution_file
     inputs.setdefault('load_neutrals', 0)
+    inputs.setdefault('output_neutral_reservoir', 1)
     inputs.setdefault('stark_components', 0)
     inputs.setdefault('flr', 2)
     inputs.setdefault('seed', -1)
@@ -1202,6 +1203,7 @@ def write_namelist(filename, inputs):
         f.write("seed = {:d}    !! RNG Seed. If seed is negative a random seed is used\n".format(inputs['seed']))
         f.write("flr = {:d}    !! Turn on Finite Larmor Radius corrections\n".format(inputs['flr']))
         f.write("load_neutrals = {:d}    !! Load neutrals from neutrals file\n".format(inputs['load_neutrals']))
+        f.write("output_neutral_reservoir = {:d}    !! Output neutral reservoir to neutrals file\n".format(inputs['output_neutral_reservoir']))
         f.write("neutrals_file = '" + inputs['neutrals_file'] + "'    !! File containing the neutral density\n")
         f.write("stark_components = {:d}    !! Output stark components\n".format(inputs['stark_components']))
         f.write("verbose = {:d}    !! Verbose\n\n".format(inputs['verbose']))

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -119,7 +119,7 @@ integer :: n_thermal = 1
 real(Float64) :: thermal_mass(max_species) = 0.d0
     !+ Thermal ion species mass [amu]
 real(Float64) :: thermal_lambda0(max_species) = 0.d0
-    !+ Reference wavelengths for thermal species/isotopes
+    !+ Reference wavelengths for thermal species/isotopes [nm]
 integer :: impurity_charge = 1
     !+ Charge of main impurity (boron=5, carbon=6,...)
 real(Float64) :: impurity_mass = 0.d0
@@ -5111,6 +5111,19 @@ subroutine write_spectra
             call h5ltset_attribute_string_f(fid,"/halo","units","Ph/(s*nm*sr*m^2)",error )
         endif
     endif
+
+    if((inputs%calc_halo.ge.1) .or. (inputs%calc_dcx.ge.1)) then
+       call h5ltmake_compressed_dataset_double_f(fid, "/thermal_mass", 1, dims(4:4), thermal_mass(1:n_thermal), error)
+       call h5ltset_attribute_string_f(fid,"/thermal_mass","description", &
+            "Mass of each of the thermal ions: thermal_mass(species)", error)
+       call h5ltset_attribute_string_f(fid,"/thermal_mass", "units", "amu", error)
+
+       call h5ltmake_compressed_dataset_double_f(fid, "/thermal_lambda0", 1, dims(4:4), thermal_lambda0(1:n_thermal), error)
+       call h5ltset_attribute_string_f(fid,"/thermal_lambda0","description", &
+            "Rest wavelength of the thermal species lines: thermal_lambda0(species)", error)
+       call h5ltset_attribute_string_f(fid,"/thermal_lambda0", "units", "nm", error)
+    endif
+
 
     if(inputs%calc_cold.ge.1) then
         spec%cold = factor*spec%cold

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -997,7 +997,7 @@ type SimulationInputs
         !+ Total number of spectral switches on
     integer(Int32) :: load_neutrals
         !+ Load neutrals from file: 0 = off, 1=on
-    integer(Int32) :: output_reservoir
+    integer(Int32) :: output_neutral_reservoir
         !+ Output neutral reservoir: 0 = off, 1=on
     integer(Int32) :: calc_npa
         !+ Calculate Active NPA: 0 = off, 1=on, 2=on++
@@ -1874,7 +1874,7 @@ subroutine read_inputs
     integer            :: calc_fida, calc_pfida, calc_npa, calc_pnpa
     integer            :: calc_birth,calc_fida_wght,calc_npa_wght
     integer            :: load_neutrals,verbose,flr,split,stark_components
-    integer            :: output_reservoir
+    integer            :: output_neutral_reservoir
     integer(Int64)     :: n_fida,n_pfida,n_npa,n_pnpa,n_nbi,n_halo,n_dcx,n_birth
     integer(Int32)     :: shot,nlambda,ne_wght,np_wght,nphi_wght,nlambda_wght
     real(Float64)      :: time,lambdamin,lambdamax,emax_wght
@@ -1891,7 +1891,7 @@ subroutine read_inputs
         calc_pfida, calc_npa, calc_pnpa,calc_birth, seed, flr, split, &
         calc_fida_wght, calc_npa_wght, load_neutrals, verbose, stark_components, &
         calc_neutron, n_fida, n_pfida, n_npa, n_pnpa, n_nbi, n_halo, n_dcx, n_birth, &
-        ab, pinj, einj, current_fractions, output_reservoir, &
+        ab, pinj, einj, current_fractions, output_neutral_reservoir, &
         nx, ny, nz, xmin, xmax, ymin, ymax, zmin, zmax, &
         origin, alpha, beta, gamma, &
         ne_wght, np_wght, nphi_wght, &
@@ -1932,7 +1932,7 @@ subroutine read_inputs
     calc_fida_wght=0
     calc_npa_wght=0
     load_neutrals=0
-    output_reservoir=1
+    output_neutral_reservoir=1
     verbose=0
     calc_neutron=0
     n_fida=0
@@ -2045,7 +2045,7 @@ subroutine read_inputs
 
     !! Misc. Settings
     inputs%load_neutrals=load_neutrals
-    inputs%output_reservoir=output_reservoir
+    inputs%output_neutral_reservoir=output_neutral_reservoir
 
     inputs%verbose=verbose
     inputs%flr = flr
@@ -4487,7 +4487,7 @@ subroutine write_neutral_population(id, pop, error)
     enddo
 
     !Create reservoir group
-    if(inputs%output_reservoir.eq.1) then
+    if(inputs%output_neutral_reservoir.eq.1) then
        call h5gcreate_f(id, "reservoir", gid, error)
        call h5ltset_attribute_string_f(id,"reservoir","description", &
             "Neutral Particle Reservoir",error)

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -997,6 +997,8 @@ type SimulationInputs
         !+ Total number of spectral switches on
     integer(Int32) :: load_neutrals
         !+ Load neutrals from file: 0 = off, 1=on
+    integer(Int32) :: output_reservoir
+        !+ Output neutral reservoir: 0 = off, 1=on
     integer(Int32) :: calc_npa
         !+ Calculate Active NPA: 0 = off, 1=on, 2=on++
     integer(Int32) :: calc_pnpa
@@ -1872,6 +1874,7 @@ subroutine read_inputs
     integer            :: calc_fida, calc_pfida, calc_npa, calc_pnpa
     integer            :: calc_birth,calc_fida_wght,calc_npa_wght
     integer            :: load_neutrals,verbose,flr,split,stark_components
+    integer            :: output_reservoir
     integer(Int64)     :: n_fida,n_pfida,n_npa,n_pnpa,n_nbi,n_halo,n_dcx,n_birth
     integer(Int32)     :: shot,nlambda,ne_wght,np_wght,nphi_wght,nlambda_wght
     real(Float64)      :: time,lambdamin,lambdamax,emax_wght
@@ -1888,7 +1891,7 @@ subroutine read_inputs
         calc_pfida, calc_npa, calc_pnpa,calc_birth, seed, flr, split, &
         calc_fida_wght, calc_npa_wght, load_neutrals, verbose, stark_components, &
         calc_neutron, n_fida, n_pfida, n_npa, n_pnpa, n_nbi, n_halo, n_dcx, n_birth, &
-        ab, pinj, einj, current_fractions, &
+        ab, pinj, einj, current_fractions, output_reservoir, &
         nx, ny, nz, xmin, xmax, ymin, ymax, zmin, zmax, &
         origin, alpha, beta, gamma, &
         ne_wght, np_wght, nphi_wght, &
@@ -1929,6 +1932,7 @@ subroutine read_inputs
     calc_fida_wght=0
     calc_npa_wght=0
     load_neutrals=0
+    output_reservoir=1
     verbose=0
     calc_neutron=0
     n_fida=0
@@ -2041,6 +2045,8 @@ subroutine read_inputs
 
     !! Misc. Settings
     inputs%load_neutrals=load_neutrals
+    inputs%output_reservoir=output_reservoir
+
     inputs%verbose=verbose
     inputs%flr = flr
     inputs%stark_components = stark_components
@@ -4481,27 +4487,28 @@ subroutine write_neutral_population(id, pop, error)
     enddo
 
     !Create reservoir group
-    call h5gcreate_f(id, "reservoir", gid, error)
-    call h5ltset_attribute_string_f(id,"reservoir","description", &
-         "Neutral Particle Reservoir",error)
+    if(inputs%output_reservoir.eq.1) then
+       call h5gcreate_f(id, "reservoir", gid, error)
+       call h5ltset_attribute_string_f(id,"reservoir","description", &
+            "Neutral Particle Reservoir",error)
 
-    call h5ltmake_dataset_int_f(gid,"k", 0, d, [maxval(pop%res%k)], error)
-    call h5ltset_attribute_string_f(gid,"k","description", &
-         "Reservoir Size", error)
+       call h5ltmake_dataset_int_f(gid,"k", 0, d, [maxval(pop%res%k)], error)
+       call h5ltset_attribute_string_f(gid,"k","description", &
+            "Reservoir Size", error)
 
-    call h5ltmake_compressed_dataset_int_f(gid, "n", 3, dims4(2:4), n, error)
-    call h5ltset_attribute_string_f(gid, "n", "description", &
-         "Number of particles in each reservoir", error)
+       call h5ltmake_compressed_dataset_int_f(gid, "n", 3, dims4(2:4), n, error)
+       call h5ltset_attribute_string_f(gid, "n", "description", &
+            "Number of particles in each reservoir", error)
 
-    call h5ltmake_compressed_dataset_double_f(gid, "w", 4, dims5(2:5), w, error, compress=.False.)
-    call h5ltset_attribute_string_f(gid, "w", "description", &
-         "Neutral Particle Weight", error)
+       call h5ltmake_compressed_dataset_double_f(gid, "w", 4, dims5(2:5), w, error, compress=.False.)
+       call h5ltset_attribute_string_f(gid, "w", "description", &
+            "Neutral Particle Weight", error)
 
-    call h5ltmake_compressed_dataset_double_f(gid, "v", 5, dims5, v, error, compress=.False.)
-    call h5ltset_attribute_string_f(gid,"v","units","cm/s",error)
-    call h5ltset_attribute_string_f(gid,"v","description", &
-         "Neutral Particle velocity in beam grid coordinates v(:,particle,i,j,k)", error)
-
+       call h5ltmake_compressed_dataset_double_f(gid, "v", 5, dims5, v, error, compress=.False.)
+       call h5ltset_attribute_string_f(gid,"v","units","cm/s",error)
+       call h5ltset_attribute_string_f(gid,"v","description", &
+            "Neutral Particle velocity in beam grid coordinates v(:,particle,i,j,k)", error)
+    endif
     !Close grid group
     call h5gclose_f(gid, error)
 

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -2219,10 +2219,12 @@ subroutine identify_transition(n_stark, stark_pi, stark_sigma, &
 
         allocate(stark_sigma(n_stark))
         stark_sigma = 1 - stark_pi
-        
-        write(*, '(a)') "---- Identify Transition ----"
-        write(*, '(a)') "The Transition is Balmer-alpha."
-        write(*,*) ''
+        if(inputs%verbose.ge.1) then
+           write(*, '(a)') "---- Identify Transition ----"
+           write(*, '(a)') "The Transition is Balmer-alpha."
+           write(*,*) ''
+        endif
+
 
     else if (inputs%lambdamin > 103.0d0 .and. inputs%lambdamax < 136.0d0) then
         ! Assigns stark varibales to Lyman alpha transition
@@ -2245,9 +2247,12 @@ subroutine identify_transition(n_stark, stark_pi, stark_sigma, &
         allocate(stark_sigma(n_stark))
         stark_sigma = 1 - stark_pi
        
-        write(*, '(a)') "---- Identify Transition ----"
-        write(*, '(a)') "The Transition is Lyman-alpha."
-        write(*,*) ''
+        if(inputs%verbose.ge.1) then
+           write(*, '(a)') "---- Identify Transition ----"
+           write(*, '(a)') "The Transition is Lyman-alpha."
+           write(*,*) ''
+        endif
+
    endif
   
 end subroutine identify_transition


### PR DESCRIPTION
* Make emission line less verbose in the MPI version of executable
* Make outputting the neutral reservoir to the neutrals file optional to reduce file size (was getting too many 2GB files...)