### PR TITLE
Lam/jlib

### DIFF
--- a/makefile
+++ b/makefile
@@ -157,7 +157,7 @@ export L_FLAGS
 export I_FLAGS
 export NTHREADS
 
-fidasim: deps src tables python
+fidasim: deps src tables python cx_helper
 
 .PHONY: deps
 deps:
@@ -170,6 +170,10 @@ src:
 .PHONY: tables
 tables: src
 	@cd $(TABLES_DIR); make
+
+.PHONY: cx_helper
+cx_helper:
+	@cd $(SRC_DIR);make cx_helper.so
 
 .PHONY: docs
 docs:

--- a/src/cx_helper.f90
+++ b/src/cx_helper.f90
@@ -1,7 +1,7 @@
 module cx_helper
     implicit none
     private
-    public :: cx_matrix
+    public :: cx_matrix, cx_rates
     contains
     subroutine cx_matrix(velocity,nlevels,rates) bind(C,name="cx_matrix")!{{{
         !! Calculate the charge-exchange cross-section matrix for a given relative collision velocity in [cm/s].
@@ -36,4 +36,39 @@ module cx_helper
         !! CX reaction rate in units [1/s] (ie, reactions per incident fast ion per second, use the fast ion velocity to get a decay length, or the fast ion density to get a volumetric rate)
         !! The rate has 'nlev' values, for each of the energy levels that the post-CX fast neutral could have
     end subroutine cx_matrix!}}}
+
+    subroutine cx_rates(denn,vn,vi,num_ions,nlevels,rates) bind(C,name="cx_rates")!{{{
+        !! Calculate the charge-exchange rates for an array of fast ions velocity vectors
+        !! with a specific neutral energy level density distribution
+        !! and fixed neutral velocity vector.
+        !! The output array gives rates of the production of outgoing energy levels of neutral, up to n=6
+        !! The rates are given in [per particle per second]
+        use libfida, only : SimulationInputs,bb_cx_rates,read_tables, nlevs,inputs,impurity_charge
+        use, intrinsic :: iso_c_binding, only: c_int64_t, c_double
+        implicit none
+        integer(c_int64_t), intent(in) :: nlevels
+        integer(c_int64_t), intent(in) :: num_ions !! Length of the array of ion velocities
+        real(c_double), dimension(nlevels,nlevels), intent(inout) :: rates !! catches the output from bb_cx_rates
+        integer :: i_ion !! index for looping over the ions
+        real(c_double), dimension(nlevels), intent(in) :: denn  !! density [cm^-3] of each energy state of neutrals
+        real(c_double), dimension(3), intent(in) :: vn !! cm/s x,y,z components of velocity of neutral
+        real(c_double), dimension(3,num_ions) , intent(in):: vi !! velocity of ions
+        if (nlevels .gt. nlevs) then
+            print *,"nlevels must be less than ",nlevs
+            stop
+        endif 
+        impurity_charge = 6
+        
+        inputs%verbose = 1
+        inputs%tables_file = '/Users/lmorton/Code/FIDASIM_lib/tables/atomic_tables.h5'
+        inputs%calc_neutron = 0
+        if () then
+            call read_tables
+        endif
+        do i_ion=1,num_ions
+            call bb_cx_rates(denn,vn,vi(:,i_ion),rates(:,i_ion))
+        enddo
+        !! CX reaction rate in units [1/s] (ie, reactions per incident fast ion per second, use the fast ion velocity to get a decay length, or the fast ion density to get a volumetric rate)
+        !! The rate has 'nlev' values, for each of the energy levels that the post-CX fast neutral could have
+    end subroutine cx_rates!}}}
 end module cx_helper

--- a/src/cx_helper.f90
+++ b/src/cx_helper.f90
@@ -1,24 +1,29 @@
 module cx_helper
     implicit none
+    private
+    public :: cx_matrix
     contains
-    subroutine cx_matrix(velocity,rates)
+    subroutine cx_matrix(velocity,nlevels,rates) bind(C,name="cx_matrix")!{{{
         !! Calculate the charge-exchange cross-section matrix for a given relative collision velocity in [cm/s].
         !! The matrix gives rates of the incoming (n) & outgoing (n') energy levels of the electron, up to n=6
         !! The rates are given in [cm^-3*s^-1]
         use libfida, only : SimulationInputs,bb_cx_rates,read_tables, nlevs,inputs,impurity_charge
+        use, intrinsic :: iso_c_binding, only: c_int, c_double
         implicit none
-        integer, parameter   :: Float64 = 8 !!Use 8-byte floats (ie, Float64)
-        real(Float64), intent(in) :: velocity
-        real(Float64), dimension(nlevs,nlevs), intent(out) :: rates !! catches the output from bb_cx_rates
+        real(c_double), intent(in) :: velocity
+        integer, intent(in) :: nlevels
+        real(c_double), dimension(nlevels,nlevels), intent(inout) :: rates !! catches the output from bb_cx_rates
         integer :: n_in !! incoming neutral energy level (principle quantum number)
-        real(Float64), dimension(nlevs) :: denn  !! density [cm^-3] of each energy state of neutrals
-        real(Float64), dimension(3) :: vn = [0.0,0.0,0.0] !! cm/s x,y,z components of velocity of neutral
-        real(Float64), parameter, dimension(3) :: vi = [0.0,0.0,0.0]!! velocity of ion
-       
+        real(c_double), dimension(nlevels) :: denn  !! density [cm^-3] of each energy state of neutrals
+        real(c_double), dimension(3) :: vn = [0.0,0.0,0.0] !! cm/s x,y,z components of velocity of neutral
+        real(c_double), parameter, dimension(3) :: vi = [0.0,0.0,0.0]!! velocity of ion
+        if (nlevels .gt. nlevs) then
+            print *,"nlevels must be less than ",nlevs
+            stop
+        endif 
         vn(1) = velocity
         impurity_charge = 6
-        
-        !!type(SimulationInputs) :: inputs !! needed to specify a few key things used in the rate calculator
+
         inputs%verbose = 1
         inputs%tables_file = '/Users/lmorton/Code/FIDASIM_lib/tables/atomic_tables.h5'
         inputs%calc_neutron = 0
@@ -27,9 +32,8 @@ module cx_helper
             denn = 0.0
             denn(n_in) = 1.0
             call bb_cx_rates(denn,vn,vi,rates(n_in,:))
-            print *,rates(n_in,:)
         enddo
         !! CX reaction rate in units [1/s] (ie, reactions per incident fast ion per second, use the fast ion velocity to get a decay length, or the fast ion density to get a volumetric rate)
         !! The rate has 'nlev' values, for each of the energy levels that the post-CX fast neutral could have
-    end subroutine cx_matrix
+    end subroutine cx_matrix!}}}
 end module cx_helper

--- a/src/cx_helper.f90
+++ b/src/cx_helper.f90
@@ -1,0 +1,35 @@
+module cx_helper
+    implicit none
+    contains
+    subroutine cx_matrix(velocity,rates)
+        !! Calculate the charge-exchange cross-section matrix for a given relative collision velocity in [cm/s].
+        !! The matrix gives rates of the incoming (n) & outgoing (n') energy levels of the electron, up to n=6
+        !! The rates are given in [cm^-3*s^-1]
+        use libfida, only : SimulationInputs,bb_cx_rates,read_tables, nlevs,inputs,impurity_charge
+        implicit none
+        integer, parameter   :: Float64 = 8 !!Use 8-byte floats (ie, Float64)
+        real(Float64), intent(in) :: velocity
+        real(Float64), dimension(nlevs,nlevs), intent(out) :: rates !! catches the output from bb_cx_rates
+        integer :: n_in !! incoming neutral energy level (principle quantum number)
+        real(Float64), dimension(nlevs) :: denn  !! density [cm^-3] of each energy state of neutrals
+        real(Float64), dimension(3) :: vn = [0.0,0.0,0.0] !! cm/s x,y,z components of velocity of neutral
+        real(Float64), parameter, dimension(3) :: vi = [0.0,0.0,0.0]!! velocity of ion
+       
+        vn(1) = velocity
+        impurity_charge = 6
+        
+        !!type(SimulationInputs) :: inputs !! needed to specify a few key things used in the rate calculator
+        inputs%verbose = 1
+        inputs%tables_file = '/Users/lmorton/Code/FIDASIM_lib/tables/atomic_tables.h5'
+        inputs%calc_neutron = 0
+        call read_tables
+        do n_in=1,6
+            denn = 0.0
+            denn(n_in) = 1.0
+            call bb_cx_rates(denn,vn,vi,rates(n_in,:))
+            print *,rates(n_in,:)
+        enddo
+        !! CX reaction rate in units [1/s] (ie, reactions per incident fast ion per second, use the fast ion velocity to get a decay length, or the fast ion density to get a volumetric rate)
+        !! The rate has 'nlev' values, for each of the energy levels that the post-CX fast neutral could have
+    end subroutine cx_matrix
+end module cx_helper

--- a/src/cx_helper.f90
+++ b/src/cx_helper.f90
@@ -54,11 +54,11 @@ module cx_helper
         !! The output array gives rates of the production of outgoing energy levels of neutral, up to n=6
         !! The rates are given in [per particle per second]
         use libfida, only : bb_cx_rates, nlevs
-        use, intrinsic :: iso_c_binding, only: c_int64_t, c_double
+        use, intrinsic :: iso_c_binding, only: c_long, c_double
         implicit none
-        integer(c_int64_t), intent(in) :: nlevels
-        integer(c_int64_t), intent(in) :: num_ions !! Length of the array of ion velocities
-        real(c_double), dimension(nlevels,nlevels), intent(inout) :: rates !! catches the output from bb_cx_rates
+        integer(c_long), intent(in) :: nlevels
+        integer(c_long), intent(in) :: num_ions !! Length of the array of ion velocities
+        real(c_double), dimension(nlevels,num_ions), intent(inout) :: rates !! catches the output from bb_cx_rates
         integer :: i_ion !! index for looping over the ions
         real(c_double), dimension(nlevels), intent(in) :: denn  !! density [cm^-3] of each energy state of neutrals
         real(c_double), dimension(3), intent(in) :: vn !! cm/s x,y,z components of velocity of neutral

--- a/src/cx_helper.jl
+++ b/src/cx_helper.jl
@@ -1,7 +1,6 @@
-
 function cx_matrix(velocity::Float64)
-    #convert velocity 
-    σ = Array{Float64,2}(undef, 6,6)
-    ccall((:__cx_helper_MOD_cx_matrix, "./cx_helper.so"), Cvoid, (Ptr{Float64},Ptr{Float64}), Ref(velocity),σ)
+    nlevs = Int32(6) #Maximum is 6, but can be lower
+    σ = Array{Float64,2}(undef,nlevs,nlevs)
+    ccall((:cx_matrix, "./cx_helper.so"), Cvoid, (Ptr{Float64},Ref{Int32},Ptr{Float64}), Ref(velocity),Ref(nlevs),σ)
     return σ
 end

--- a/src/cx_helper.jl
+++ b/src/cx_helper.jl
@@ -1,0 +1,7 @@
+
+function cx_matrix(velocity::Float64)
+    #convert velocity 
+    σ = Array{Float64,2}(undef, 6,6)
+    ccall((:__cx_helper_MOD_cx_matrix, "./cx_helper.so"), Cvoid, (Ptr{Float64},Ptr{Float64}), Ref(velocity),σ)
+    return σ
+end

--- a/src/cx_helper.jl
+++ b/src/cx_helper.jl
@@ -4,3 +4,14 @@ function cx_matrix(velocity::Float64)
     ccall((:cx_matrix, "./cx_helper.so"), Cvoid, (Ptr{Float64},Ref{Int32},Ptr{Float64}), Ref(velocity),Ref(nlevs),σ)
     return σ
 end
+
+function cx_rates(neutral_density::Array{Float64,1},neutral_velocity::Array{Float64,1},ion_velocities::Array{Float64,2})
+    nlevs = Int64(6)
+    @assert size(ion_velocities,1) == 3
+    @assert size(neutral_density,1) == nlevs
+    @assert size(neutral_velocity,1) == 3
+    num_ions = size(ion_velocities,2)
+    rates = Array{Float64,2}(undef,nlevs,num_ions)
+    ccall((:cx_rates,"./cx_helper.so"),Cvoid,(Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Int64},Ptr{Int64},Ptr{Float64}),neutral_density,neutral_velocity,ion_velocities,Ref(num_ions),Ref(nlevs),rates)
+    return rates
+end

--- a/src/cx_helper.py
+++ b/src/cx_helper.py
@@ -1,0 +1,56 @@
+from cffi import FFI
+import numpy as np
+ffi = FFI()
+lib = ffi.dlopen("/Users/lmorton/Code/FIDASIM_lib/src/cx_helper.so")
+ffi.cdef("void cx_matrix(double arg1[], int arg2[], double arg3[]);")
+ffi.cdef("void cx_rates(double arg1[], double arg2[], double arg3[], long arg4[], long arg5[], double arg6[]);")
+converter = {'float64':'double*',
+            'int32':'int*',
+            'int64':'long*'}
+def ref(x):
+    """
+    Convert array to pointer suitable for consumption by C/fortran
+    """
+    xdtype = x.dtype
+    ctype = converter[xdtype.name]
+    return ffi.cast(ctype,x.__array_interface__['data'][0])
+
+def scalar(x,ctype):
+    """
+    Array-wrap non-arrays, especially scalars
+    """
+    return np.array(x,dtype=ctype,order='F')
+
+def unscalar(x):
+    """
+    Unwrap single-element array
+    """
+    return x.item()
+
+def scref(x,ctype):
+    return ref(scalar(x,ctype))
+
+def cx_matrix(velocity):
+    nlevels = 6
+    arg3 = np.empty((nlevels,nlevels),order='F',dtype= 'float64')
+    lib.cx_matrix(scref(velocity,'float64'),
+                 scref(nlevels,'int32'),
+                 ref(arg3),)
+    return arg3
+
+def cx_rates(neutral_density,neutral_velocity,ion_velocities):
+    space_dimensions = 3
+    nlevels = 6
+    assert neutral_density.shape == (nlevels,)
+    assert neutral_velocity.shape == (space_dimensions,)
+    assert ion_velocities.shape[0] == space_dimensions
+    assert ion_velocities.ndim == 2
+    num_ions = ion_velocities.shape[1]
+    rates = np.empty((nlevels,num_ions),dtype='float64')
+    lib.cx_rates(ref(neutral_density),
+                ref(neutral_velocity),
+                ref(ion_velocities),
+                scref(num_ions,'int64'),
+                scref(nlevels,'int64'),
+                ref(rates))
+    return rates

--- a/src/cx_tester.jl
+++ b/src/cx_tester.jl
@@ -1,0 +1,13 @@
+neutral_density = [1.0,0.,0.,0.,0.,0.]
+neutral_velocity = [0.,0.,0.]
+start = 6
+stop = 9
+length = 50
+function logspace(start,stop,length=50)
+    exp10.(range(start, stop=stop, length=length))
+end
+ion_velocities = Array{Float64,2}(undef,3,length)
+ion_velocities[2:end,:] .= 0
+ion_velocities[1,:] = logspace(start,stop,length)
+cx_rate_results = cx_rates(neutral_density,neutral_velocity,ion_velocities)
+

--- a/src/cx_tester.jl
+++ b/src/cx_tester.jl
@@ -11,3 +11,12 @@ ion_velocities[2:end,:] .= 0
 ion_velocities[1,:] = logspace(start,stop,length)
 cx_rate_results = cx_rates(neutral_density,neutral_velocity,ion_velocities)
 
+using Plots
+plotly()
+
+plot(ion_velocities[1,:], cx_rate_results[1,:],ticks = :native)
+#Need to transpose to get alignment of shapes for automatically plotting multiple lines, one for each energy level
+plot(ion_velocities[1,:], transpose(cx_rate_results),ticks = :native)
+cxmin = minimum(cx_rate_results[cx_rate_results.>0.0])
+plot(ion_velocities[1,:], transpose(cx_rate_results),xaxis=:log,yaxis=:log,ylim=[cxmin,maximum(cx_rate_results)])
+

--- a/src/makefile
+++ b/src/makefile
@@ -25,5 +25,11 @@ utilities.mod utilities.o: utilities.f90
 hdf5_utils.mod hdf5_utils.o: hdf5_utils.f90
 	$(MPI_FC) $(C_FLAGS) -c $< $(I_FLAGS)
 
+cx_helper.so: cx_helper.o $(FIDADEPS)
+	$(MPI_FC) $(C_FLAGS) $^ -o $@ -shared -fPIC $(L_FLAGS)
+
+cx_helper.mod cx_helper.o: cx_helper.f90
+	$(MPI_FC) $(C_FLAGS) -c $< $(I_FLAGS)
+
 clean:
 	-rm -f *.mod *.o


### PR DESCRIPTION
This is my first pass at making Python & Julia interfaces to subroutines in `fidasim.f90` module `libfida`.  I modified the `make` instructions to produce a `.so` shared object for the Fortran wrappers in `cx_helper.f90.`  This file uses C bindings to avoid Fortran name-mangling & standardize the numeric `kinds`.  The wrappers also to manage hidden global variables (ex: atomic tables) to allow the subroutines to function autonomously. This approach does not require modifications to `fidasim.f90.`  However, it might be more convenient in the future to bring the C bindings directly into `fidasim.f90`. 

Julia uses `ccall` to easily call the shared library. I'm using the `CFFI` (C foreign function interface) library in Python. There's a lot of boilerplate involved. 