### PR TITLE
Needs prefida label from PR #218 bug fix

### DIFF
--- a/lib/scripts/plot_inputs
+++ b/lib/scripts/plot_inputs
@@ -468,7 +468,7 @@ def main():
             plt.tight_layout()
 
             #Save
-            important_labels = ['Te','Ti','Nd','Ne','Nn']
+            important_labels = ['Te','Ti','Ni','Ne','Nn']
             if len(args.saveimportant)>0 and fig_labels[i] in important_labels:
                 plt.savefig(args.saveimportant+fig_labels[i])
 

--- a/lib/scripts/plot_inputs
+++ b/lib/scripts/plot_inputs
@@ -207,7 +207,7 @@ def main():
     lineouts[1,2,1] = args.rplineout
 
     # Set colormap
-    cmap = cm.get_cmap('viridis', args.nlevels)
+    cmap = cm.get_cmap('inferno', args.nlevels)
     cmap_list = ["black"]
     for i in range(cmap.N):
         rgb = cmap(i)

--- a/test/run_tests.pro
+++ b/test/run_tests.pro
@@ -52,7 +52,7 @@ PRO run_tests,result_dir,runid = runid
 
    pfile = test_dir+'test_profiles.cdf'
    plasma = test_profiles(pfile,grid,rho)
-   plasma.deni = (plasma.deni - rebin(fbm.denf,1,grid.nr,grid.nz)) > 0.0
+   plasma.deni = (plasma.deni - reform(fbm.denf,1,grid.nr,grid.nz)) > 0.0
 
    prefida,inputs, grid, nbi, plasma, equil, fbm, spec=spec, npa=npa
 

--- a/test/test_profiles.pro
+++ b/test/test_profiles.pro
@@ -28,7 +28,7 @@ FUNCTION test_profiles,filename,grid,rhogrid
     nz = n_elements(dene[0,*])
     dene=rebin(dene,nr,nz,grid.nphi)
     denimp=rebin(denimp,nr,nz,grid.nphi)
-    deni=rebin(denimp,nthermal,nr,nz,grid.nphi)
+    deni=reform(deni,nthermal,nr,nz,grid.nphi)
     denn=rebin(denn,nr,nz,grid.nphi)
     mask=rebin(mask,nr,nz,grid.nphi)
     te=rebin(te,nr,nz,grid.nphi)


### PR DESCRIPTION
Luke,

I fixed the prefida bug @shaunhaskey found in [PR #218](https://github.com/D3DEnergetic/FIDASIM/pull/218). Both IDL and Python output correct Ni profiles for the test cases.

![Ni_idl](https://user-images.githubusercontent.com/33560765/106177552-8368ed80-614d-11eb-96ea-f0f380fdcfac.png)

Please merge in this branch and remove the "needs prefida" label from the previous PR. Thanks.