### PR TITLE
Fix hdf5 error messages when output_neutral_reservoir=0

### DIFF
--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -4718,9 +4718,9 @@ subroutine write_neutral_population(id, pop, error)
        call h5ltset_attribute_string_f(gid,"v","units","cm/s",error)
        call h5ltset_attribute_string_f(gid,"v","description", &
             "Neutral Particle velocity in beam grid coordinates v(:,particle,i,j,k)", error)
+       !Close reservoir group
+       call h5gclose_f(gid, error)
     endif
-    !Close grid group
-    call h5gclose_f(gid, error)
 
     deallocate(v,w,n)
 


### PR DESCRIPTION
![2021-05-18_12-20](https://user-images.githubusercontent.com/3589208/118714550-76910800-b7d7-11eb-9b51-ca20eaf989ca.png)
