### PR TITLE
Support for compiling using flang/clang on modern AMD hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,5 @@ This will build the documentation website in the `docs/html` directory.
 
 The above command will also check the website for dead links which requires [linkchecker](https://wummel.github.io/linkchecker/) to be installed.
 This functionality can be disabled by passing the `CHECK_LINKS=n` build option to the `make docs` command. 
+
+test

--- a/makefile
+++ b/makefile
@@ -20,9 +20,9 @@ PYTHON_EXEC = $(shell which python)
 OS := $(shell uname)
 
 #Compilers
-SUPPORTED_FC = gfortran pgf90 ifort
-SUPPORTED_CC = gcc pgcc
-SUPPORTED_CXX = g++ pgc++
+SUPPORTED_FC = gfortran pgf90 ifort flang
+SUPPORTED_CC = gcc pgcc clang
+SUPPORTED_CXX = g++ pgc++ clang 
 
 HAS_FC := $(strip $(foreach SC, $(SUPPORTED_FC), $(findstring $(SC), $(FC))))
 ifeq ($(HAS_FC),)
@@ -103,6 +103,17 @@ ifneq ($(findstring ifort, $(FC)),)
         PROF_FLAGS = -p -D_PROF
 ifneq ($(ARCH),n)
         COMMON_CFLAGS := $(COMMON_CFLAGS) -x$(ARCH)
+endif
+endif
+ifneq ($(findstring flang, $(FC)),)
+        L_FLAGS = -lm
+        COMMON_CFLAGS = -O3 -mfma -fvectorize -mfma -mavx2 -m3dnow -floop-unswitch-aggressive -Mpreprocess
+        DEBUG_CFLAGS = -O0 -g -cpp -fbacktrace -fcheck=all -Wall -ffpe-trap=invalid,zero,overflow -D_DEBUG
+        OPENMP_FLAGS = -fopenmp -D_OMP
+        MPI_FLAGS = -D_MPI
+        PROF_FLAGS = -pg -D_PROF
+ifneq ($(ARCH),n)
+        COMMON_CFLAGS := $(COMMON_CFLAGS) -march=$(ARCH)
 endif
 endif
 


### PR DESCRIPTION
Excellent compiler optimizations are still WIP here, but FIDASIM now compiles and runs using the AMD AOCC Compiler and is good.

Be sure that you have the compiler installed and set up following the AMD documentation here:
https://www.amd.com/en/developer/aocc.html

Internally tested on AMD Zen 2 hardware.