### PR TITLE
Whjh/prefida vmec

### DIFF
--- a/lib/python/fidasim/utils.py
+++ b/lib/python/fidasim/utils.py
@@ -810,7 +810,7 @@ def read_geqdsk(filename, grid, poloidal=False, ccw_phi=True, exp_Bp=0, **conver
     z_pts = grid['z2d'].flatten()/100
 
     g = efit.readg(filename)
-    cc = identify_COCOS(g, ccw_phi=ccw_phi, exp_Bp=exp_Bp)
+    cc = identify_COCOS_from_geqdsk(g, ccw_phi=ccw_phi, exp_Bp=exp_Bp)
 
     cc_factor = cc.sigma_RphZ*cc.sigma_Bp/((2*np.pi)**cc.exp_Bp)
 
@@ -876,16 +876,16 @@ def transform_COCOS_from_geqdsk(g, ccw_phi=True, exp_Bp=0, **convert_COCOS_kw):
     '''
     cc_out = COCOS() # cc_out = FIDASIM COCOS
     
-    cc_in = identify_COCOS(g, ccw_phi=ccw_phi, exp_Bp=exp_Bp)
+    cc_in = identify_COCOS_from_geqdsk(g, ccw_phi=ccw_phi, exp_Bp=exp_Bp)
     
     if cc_in.cocos != cc_out.cocos:
         return convert_COCOS(g.copy(), cc_in, cc_out, **convert_COCOS_kw)
     else:
         return g.copy()
 
-def identify_COCOS(g, ccw_phi=True, exp_Bp=0):
+def identify_COCOS_from_geqdsk(g, ccw_phi=True, exp_Bp=0):
     '''
-    #+#identify_COCOS
+    #+#identify_COCOS_from_geqdsk
     #+Identifies the COCOS index of a GEQDSK dictionary object
     #+Reference:
     #+    O. Sauter and S. Yu. Medvedev, Tokamak Coordinate Conventions: COCOS, 
@@ -905,14 +905,39 @@ def identify_COCOS(g, ccw_phi=True, exp_Bp=0):
     #+##Example Usage
     #+```python
     #+>>> g = efit.readg(filename)
-    #+>>> g_cocos = identify_COCOS(g)
+    #+>>> g_cocos = identify_COCOS_from_geqdsk(g)
     #+```
     '''
     # Sauter, eq. 22    
     sigma_Bp_in = -1 * np.sign(g['pprime'][0] * g['current'])
     sigma_RphZ_in = 1 if ccw_phi else -1
     sigma_rhothph_in = np.sign(g['qpsi'][0] * g['current'] * g['bcentr'])
-    
+
+    index = identify_COCOS_index
+
+    return COCOS(index+(10*exp_Bp))
+
+def identify_COCOS_index(sigmas):
+    """
+    #+#identify_COCOS_index
+    #+Identifies the COCOS index from sigma_Bp, sigma_{R, phi, Z}, and sigma_{rho, theta, phi}
+    #+Reference:
+    #+    O. Sauter and S. Yu. Medvedev, Tokamak Coordinate Conventions: COCOS, 
+    #+    Computer Physics Communications 184, 293 (2013).
+    #+***
+    #+##Arguments
+    #+    **sigmas**: List-like object with values for sigma_Bp, sigma_{R, phi, Z}, and sigma_{rho, theta, phi}
+    #+
+    #+##Return Value
+    #+Index for COCOS object
+    #+
+    #+##Example Usage
+    #+```python
+    #+>>> index = identify_COCOS_index([-1, 1, -1])
+    #+>>> cocos = COCOS(index)
+    #+```
+
+    """
     sigmas = [sigma_Bp_in, sigma_RphZ_in, sigma_rhothph_in]
  
     if sigmas == [1, 1, 1]:
@@ -934,7 +959,7 @@ def identify_COCOS(g, ccw_phi=True, exp_Bp=0):
     else:
         index = FIDASIM_default_COCOS
     
-    return COCOS(index+(10*exp_Bp))
+    return index
 
 def convert_COCOS(g, cc_in, cc_out, sigma_Ip=None, sigma_B0=None, l_d=[1,1], l_B=[1,1], exp_mu0=[0,0]):
     '''

--- a/lib/python/vmec/__init__.py
+++ b/lib/python/vmec/__init__.py
@@ -1,0 +1,2 @@
+from vmec.io import read_vmec
+from vmec.utils import fourier_transform_3D, Brzp_transform

--- a/lib/python/vmec/io.py
+++ b/lib/python/vmec/io.py
@@ -17,6 +17,19 @@ from scipy.io import netcdf_file
 
 def read_vmec(file_name):
     """
+    #+#read_vmec
+    #+ Read in vmec data from `file_name`
+    #+***
+    #+##Input Arguments
+    #+    **file_name**: Name of the VMEC .wout file
+    #+
+    #+##Output Arguments
+    #+    **wout**: VMEC dictionary
+    #+
+    #+##Example Usage
+    #+```python
+    #+>>> wout = read_vmec(file_name)
+    #+```
     """
     if file_name[-3:] == '.nc': # netCDF file
         f = read_vmec_nc(file_name)
@@ -119,11 +132,24 @@ def read_vmec(file_name):
             'xm_nyq':xm_nyq, 'xn_nyq':xn_nyq, 'md_nyq':md_nyq,
             'nyq_limit':nyq_limit, 'cos_keys':cos_keys, 'sin_keys':sin_keys,
             'cos_nyq_keys':cos_nyq_keys, 'sin_nyq_keys':sin_nyq_keys,
+            'data_source':os.path.abspath(file_name),
             'keys':['R', 'Z', 'Bs', 'Bv', 'Bu', 'dR_ds', 'dR_dv', 'dR_du', 'dZ_ds', 'dZ_dv', 'dZ_du']}
-
 
 def read_vmec_nc(file_name):
     """
+    #+#read_vmec_nc
+    #+ Read in vmec data from `file_name` NETCDF file
+    #+***
+    #+##Input Arguments
+    #+    **file_name**: Name of the VMEC .wout NETCDF file
+    #+
+    #+##Output Arguments
+    #+    **wout**: VMEC dictionary
+    #+
+    #+##Example Usage
+    #+```python
+    #+>>> wout = read_vmec_nc(file_name)
+    #+```
     """
     wout_netcdf = netcdf_file(file_name, mode='r', version=4)
     f = {}
@@ -154,6 +180,19 @@ def read_vmec_nc(file_name):
 
 def read_vmec_txt(file_name):
     """
+    #+#read_vmec_txt
+    #+ Read in vmec data from `file_name` text file
+    #+***
+    #+##Input Arguments
+    #+    **file_name**: Name of the VMEC .wout text file
+    #+
+    #+##Output Arguments
+    #+    **wout**: VMEC dictionary
+    #+
+    #+##Example Usage
+    #+```python
+    #+>>> wout = read_vmec_txt(file_name)
+    #+```
     """
     print(f'Reading VMEC data from text file {os.path.abspath(file_name)}')
     data = read_vmec_txt_data(file_name)
@@ -529,9 +568,25 @@ def read_vmec_txt(file_name):
         
     return dict(sorted(f.items(), key=lambda x:x[0]))
 
-
 def read_vmec_txt_data(file_name, decode_bytes='utf-8'):
     """
+    #+#read_vmec_txt_data
+    #+ Helper function for `read_vmec_txt`
+    #+ Reads data from file_name into list object
+    #+***
+    #+##Input Arguments
+    #+    **file_name**: Name of the VMEC .wout text file
+    #+
+    #+##Keyword Arguments
+    #+     **decode_bytes**: Encoding standard
+    #+
+    #+##Output Arguments
+    #+    **data**: 1-D list object
+    #+
+    #+##Example Usage
+    #+```python
+    #+>>> data = read_vmec_txt_data(file_name, decode_bytes='utf-8')
+    #+```
     """
     with open(file_name, 'r') as file:
         flines = file.readlines()
@@ -556,10 +611,22 @@ def read_vmec_txt_data(file_name, decode_bytes='utf-8'):
 
     return data
 
-
 def h2f(var_half):
     """
-    Half to full grid
+    #+#h2f
+    #+ Helper function for `read_vmec`
+    #+ Converts half mesh objects to full mesh objects
+    #+***
+    #+##Input Arguments
+    #+    **var_half**: Half mesh data array
+    #+
+    #+##Output Arguments
+    #+    **temp**: Full mesh data array
+    #+
+    #+##Example Usage
+    #+```python
+    #+>>> temp = h2f(var_half)
+    #+```
     """
     temp = np.zeros(var_half.size)
     temp[0] = 1.5 * var_half[1] - 0.5 * var_half[2]

--- a/lib/python/vmec/io.py
+++ b/lib/python/vmec/io.py
@@ -8,43 +8,44 @@ read_vmec adapted from pyFIDASIM/vmec_read.py (author: micha) and matlabVMEC/VME
 
 import numpy as np
 
-from scipy.io import netcdf
+from scipy.io import netcdf_file
 
 def read_vmec(file_name):
     """
     """
     if file_name[-3:] == '.nc': # netCDF file
-        f = netcdf.netcdf_file(file_name, mode='r', version=4)
+        f = read_vmec_nc(file_name)
+        nc_flag = True
     else: # text file
         f = read_vmec_txt(file_name)
+        nc_flag = False
 
-    ns = f.variables['ns'].data
-
-    xm = f.variables['xm'].data
-    xn = f.variables['xn'].data
+    ns = f['ns']
+    xm = f['xm']
+    xn = f['xn']
     md = len(xm)
 
-    xm_nyq = f.variables['xm_nyq'].data
-    xn_nyq = f.variables['xn_nyq'].data
+    xm_nyq = f['xm_nyq']
+    xn_nyq = f['xn_nyq']
     md_nyq = len(xm_nyq)
 
     ds = 1. / (ns - 1)
 
-    fourierAmps = {
-            'R'        : f.variables['rmnc'].data,
-            'Z'        : f.variables['zmns'].data,
-            'Lambda'   : f.variables['lmns'].data,
-            'Bu'       : f.variables['bsubumnc'].data,
-            'Bv'       : f.variables['bsubvmnc'].data,
-            'Bs'       : f.variables['bsubsmns'].data,
-            'Bmod'     : f.variables['bmnc'].data,
-            'Jacobian' : f.variables['gmnc'].data,
-            'dR_ds'    : np.gradient(f.variables['rmnc'].data, ds, axis=0),
-            'dR_du'    : -f.variables['rmnc'].data * xm,
-            'dR_dv'    : f.variables['rmnc'].data * xn,
-            'dZ_ds'    : np.gradient(f.variables['zmns'].data, ds, axis=0),
-            'dZ_du'    : f.variables['zmns'].data * xm,
-            'dZ_dv'    : -f.variables['zmns'].data * xn
+    fourier_amps = {
+            'R'        : f['rmnc'],
+            'Z'        : f['zmns'],
+            'Lambda'   : f['lmns'],
+            'Bu'       : f['bsubumnc'],
+            'Bv'       : f['bsubvmnc'],
+            'Bs'       : f['bsubsmns'],
+            'Bmod'     : f['bmnc'],
+            'Jacobian' : f['gmnc'],
+            'dR_ds'    : np.gradient(f['rmnc'], ds, axis=0),
+            'dR_du'    : -f['rmnc'] * xm,
+            'dR_dv'    : f['rmnc'] * xn,
+            'dZ_ds'    : np.gradient(f['zmns'], ds, axis=0),
+            'dZ_du'    : f['zmns'] * xm,
+            'dZ_dv'    : -f['zmns'] * xn
             }
     
     if md == md_nyq:
@@ -67,9 +68,22 @@ def read_vmec(file_name):
     cos_keys.extend(['dR_ds', 'dZ_du', 'dZ_dv'])
     sin_keys.extend(['dR_du', 'dR_dv', 'dZ_ds'])
 
-    f.close()
+    """
+    msize = f['xm'].max()
+    nsize = max(f['xn']/f['nfp']) - min(f['xn']/f['nfp']) + 1
+    f['rbc'] = np.zeros((msize+1, nsize, f['ns']))
+    f['zbs'] = np.zeros((msize+1, nsize, f['ns']))
+    f['lbs'] = np.zeros((msize+1, nsize, f['ns']))
 
-    return {'fourierAmps':fourierAmps,
+    f['rsc'] = np.zeros((msize+1, nsize, f['ns']))
+    f['rus'] = np.zeros((msize+1, nsize, f['ns']))
+    f['rvs'] = np.zeros((msize+1, nsize, f['ns']))
+    f['zss'] = np.zeros((msize+1, nsize, f['ns']))
+    f['zuc'] = np.zeros((msize+1, nsize, f['ns']))
+    f['zvc'] = np.zeros((msize+1, nsize, f['ns']))
+    """
+
+    return {'fourierAmps':fourier_amps,
             'ns':ns, 'xm':xm, 'xn':xn, 'md':md,
             'xm_nyq':xm_nyq, 'xn_nyq':xn_nyq, 'md_nyq':md_nyq,
             'nyq_limit':nyq_limit, 'cos_keys':cos_keys, 'sin_keys':sin_keys,
@@ -77,74 +91,89 @@ def read_vmec(file_name):
             'keys':['R', 'Z', 'Bs', 'Bv', 'Bu', 'dR_ds', 'dR_dv', 'dR_du', 'dZ_ds', 'dZ_dv', 'dZ_du']}
 
 
+def read_vmec_nc(file_name):
+    """
+    """
+    wout_netcdf = netcdf_file(file_name, mode='r', version=4)
+    f = {}
+    for key, var in wout_netcdf.variables.items():
+        print(key)
+        if var.data.ndim == 0:
+            val = np.array([var.data])[0]
+            if float(val).is_integer():
+                type_id = int
+            else:
+                type_id = float
+            f[key] = type_id(val)
+        elif isinstance(var.data[0], np.bytes_):
+            f[key] = ''.join([val.decode('utf-8') for val in var.data]).strip()
+        elif var.data.ndim > 1 and isinstance(var.data[0][0], np.bytes_):
+            f[key] = [''.join([val2.decode('utf-8') for val2 in val1]).strip() for val1 in var.data]
+        else:
+            arr_val = var.data
+            if all([float(val).is_integer() for val in arr_val.flatten()]):
+                type_id = int
+            else:
+                type_id = float
+            f[key] = arr_val.astype(type_id)
+    wout_netcdf.flush()
+    wout_netcdf.fp.close()
+    wout_netcdf.close()
+    return f
+
+
 def read_vmec_txt(file_name):
     """
     """
-    with open(file_name, 'r') as file:
-        flines = file.readlines()
-
-    version = float(flines[0].strip().split()[-1])
-    if ',' in flines[1]:
-        sep = ','
-        csv = True
-    else:
-        sep = None
-        csv = False
-
-    data = [version]
-    for line in flines[1:]:
-        for val in line.strip().split(sep=sep):
-            if not val.isalpha():
-                data.append(float(val))
-    data = np.array(data) # numpy array will be easier to manipulate
-
+    data = read_vmec_txt_data(file_name)
+    
     f = {}
     cursor = 1
     #if version > 6.5 and version <= 6.95:
     f['lfreeb'] = 0
-    keys = ['wb', 'wp', 'gamma', 'pfac', 'rmax_surf', 'rmin_surf', 'zmax_surf', 'nfp', 'ns', 'mpol', 'ntor', 'mnmax', 'itfsq', 'niter', 'iasym', 'ireconstruct', 'ierr_vmec', 'imse', 'itse', 'nbsets', 'nobd', 'nextcur', 'nstore_seq']
-    for ikey, key in enumerate(keys):
-        f[key] = data[ikey+1]
+    keys = {'wb':float, 'wp':float, 'gamma':float, 'pfac':float, 'rmax_surf':float, 'rmin_surf':float, 'zmax_surf':float, 'nfp':int, 'ns':int, 'mpol':int, 'ntor':int, 'mnmax':int, 'itfsq':int, 'niter':int, 'iasym':int, 'ireconstruct':int, 'ierr_vmec':int, 'imse':int, 'itse':int, 'nbsets':int, 'nobd':int, 'nextcur':int, 'nstore_seq':int}
+    for ikey, (key, type_id) in enumerate(keys.items()):
+        f[key] = type_id(data[ikey+1])
         cursor += 1
 
     if f['ierr_vmec'] and f['ierr_vmec'] != 4:
         raise Exception(f'ierr_vmec: {f["ierr_vmec"]}')
 
     if f['nbsets'] > 0:
-        f['nbfld'] = data[cursor:cursor+f['nbsets']]
+        f['nbfld'] = data[cursor:cursor+f['nbsets']].astype(int)
         cursor += f['nbsets']
 
     if f['iasym'] > 0:
         d1_x, d2_x = 16, 14
     else:
         d1_x, d2_x = 13, 11
-    data1 = data[cursor:cursor+d1_x*f['mnmax']].reshape((d1_x, f['mnmax']))
+    data1 = data[cursor:cursor+d1_x*f['mnmax']].reshape((f['mnmax'], d1_x)).T
     cursor += d1_x*f['mnmax']
-    data2 = data[cursor:cursor+d2_x*f['mnmax']*(f['ns']-1)].reshape((d2_x, f['mnmax']*(f['ns']-1)))
+    data2 = data[cursor:cursor+d2_x*f['mnmax']*(f['ns']-1)].reshape((f['mnmax']*(f['ns']-1), d2_x)).T
     cursor += d2_x*f['mnmax']*(f['ns']-1)
 
     f['xm'] = data1[0, :].astype(int)
     f['xn'] = data1[1, :].astype(int)
 
-    keys = ['rmnc', 'zmns', 'lmns', 'bmnc', 'gmnc', 'bsubumnc', 'bsubvmnc', 'bsubsmns', 'bsupumnc', 'bsupvmnc', 'currvmnc' ]
+    keys = ['rmnc', 'zmns', 'lmns', 'bmnc', 'gmnc', 'bsubumnc', 'bsubvmnc', 'bsubsmns', 'bsupumnc', 'bsupvmnc', 'currvmnc']
     if f['iasym'] > 0:
         keys.extend(['rmns', 'zmnc', 'lmnc'])
     for ikey, key in enumerate(keys):
-        f[key] = np.vstack([data1[ikey+2, :], data2[ikey, :].reshape((f['mnmax'], f['ns'] - 1)).T]).T
+        f[key] = np.vstack([data1[ikey+2, :], data2[ikey, :].reshape((f['ns']-1, f['mnmax']))])
 
-    data3 = data[cursor:cursor+13*(f['ns']-1)].reshape((13, f['ns']-1))
+    data3 = data[cursor:cursor+13*(f['ns']-1)].reshape((f['ns']-1, 13)).T
     cursor += 13*(f['ns']-1)
     keys = ['iotas', 'mass', 'pres', 'beta_vol', 'phip', 'buco', 'bvco', 'phi', 'vp', 'overr', 'jcuru', 'jcurv', 'specw']
     for ikey, key in enumerate(keys):
         f[key] = data3[ikey, :]
 
     curs0 = cursor
-    keys = ['aspect', 'betatot', 'betapol', 'betator', 'betaxis', 'b0', 'isigna', 'input_extension', 'IonLarmor', 'VolAvgB', 'RBtor0', 'RBtor', 'Itor', 'Aminor', 'Rmajor', 'Volume']
+    keys = ['aspect', 'betatot', 'betapol', 'betator', 'betaxis', 'b0', 'isigna', 'IonLarmor', 'VolAvgB', 'RBtor0', 'RBtor', 'Itor', 'Aminor', 'Rmajor', 'Volume']
     for ikey, key in enumerate(keys):
         f[key] = data[curs0+ikey]
         cursor += 1
     
-    data4 = data[cursor:cursor+6*(f['ns']-2)].reshape((6, f['ns']-2))
+    data4 = data[cursor:cursor+6*(f['ns']-2)].reshape((f['ns']-2, 6)).T
     cursor += 6*(f['ns']-2)
     keys = ['Dmerc', 'Dshear', 'Dwell', 'Dcurr', 'Dgeod', 'equif']
     for ikey, key in enumerate(keys):
@@ -172,59 +201,65 @@ def read_vmec_txt(file_name):
             rem=rem-size(index,2)/2;
         end
         """
-    data5 = data[cursor:cursor+4*f['nstore_seq']].reshape((4, f['nstore_seq']))
-    cursor += 4*f['nstore_seq']
-    keys = ['sqt', 'wdot', 'jdotb', 'bdotgradv']
+    data5 = data[cursor:cursor+2*f['nstore_seq']].reshape((f['nstore_seq'], 2)).T
+    cursor += 2*f['nstore_seq']
+    keys = ['sqt', 'wdot']
     for ikey, key in enumerate(keys):
         f[key] = data5[ikey, :]
+
+    data6 = data[cursor:cursor+2*f['ns']].reshape((f['ns'], 2)).T
+    cursor += 2*f['ns']
+    keys = ['jdotb', 'bdotgradv']
+    for ikey, key in enumerate(keys):
+        f[key] = data6[ikey, :]
 
     if f['ireconstruct'] > 0:
         if f['imse'] >= 2 or f['itse'] > 0:
             curs0 = cursor
-            keys = ['twsgt', 'msewgt', 'isnodes']
-            for ikey, key in enumerate(keys):
-                f[key] = data[curs0+ikey]
+            keys = {'twsgt':float, 'msewgt':float, 'isnodes':int}
+            for ikey, (key, type_id) in enumerate(keys.items()):
+                f[key] = type_id(data[curs0+ikey])
                 cursor += 1
 
-            data5_1 = data[cursor:cursor+3*f['isnodes']].reshape((3, f['isnodes']))
+            data7_1 = data[cursor:cursor+3*f['isnodes']].reshape((f['isnodes'], 3)).T
             cursor += 3*f['isnodes']
             keys = ['sknots', 'ystark', 'y2stark']
             for ikey, key in enumerate(keys):
-                f[key] = data5_1[ikey, :]
+                f[key] = data7_1[ikey, :]
 
-            f['ipnodes'] = data[cursor]
+            f['ipnodes'] = float(data[cursor])
             cursor += 1
 
-            data5_2 = data[cursor:cursor+3*f['ipnodes']].reshape((3, f['ipnodes']))
+            data7_2 = data[cursor:cursor+3*f['ipnodes']].reshape((f['ipnodes'], 3)).T
             cursor += 3*f['ipnodes']
             keys = ['pknots', 'ythom', 'y2thom']
             for key, ikey in enumerate(keys):
-                f[key] = data5_2[ikey, :]
+                f[key] = data7_2[ikey, :]
 
-            data5_3 = data[cursor:cursor+7*(2*f['ns']-1)].reshape((7, 2*f['ns']-1))
+            data7_3 = data[cursor:cursor+7*(2*f['ns']-1)].reshape((2*f['ns']-1, 7)).T
             cursor += 7*(2*f['ns']-1)
             keys = ['anglemse', 'rmid', 'qmid', 'shear', 'presmid', 'alfa', 'curmid']
             for key, ikey in enumerate(keys):
-                f[key] = data5_3[ikey, :]
+                f[key] = data7_3[ikey, :]
 
-            data5_4 = data[cursor:cursor+3*f['imse']].reshape((3, f['imse']))
+            data7_4 = data[cursor:cursor+3*f['imse']].reshape((f['imse'], 3)).T
             cursor += 3*f['imse']
             keys = ['rstark', 'datastark', 'qmeas']
             for ikey, key in enumerate(keys):
-                f[key] = data5_4[ikey, :]
+                f[key] = data7_4[ikey, :]
 
-            data5_5 = data[cursor:cursor+2*f['itse']].reshape((2, f['itse']))
+            data7_5 = data[cursor:cursor+2*f['itse']].reshape((f['itse'], 2)).T
             cursor += 2*f['itse']
             keys = ['trhom', 'datathom']
             for ikey, key in enumerate(keys):
-                f[key] = data5_5[ikey, :]
+                f[key] = data7_5[ikey, :]
 
         if f['nobd'] > 0:
-            data5_6 = data[cursor:cursor+3*f['nobd']].reshape((3, f['nobd']))
+            data7_6 = data[cursor:cursor+3*f['nobd']].reshape((f['nobd'], 3)).T
             cursor += 3*f['nobd']
             keys = ['dsiext', 'plflux', 'fsiobt']
             for ikey, key in enumerate(keys):
-                f[key] = data5_6[ikey, :]
+                f[key] = data7_6[ikey, :]
 
             f['flmwgt'] = data[cursor]
             cursor += 1
@@ -235,22 +270,22 @@ def read_vmec_txt(file_name):
             f['plbfld'] = []
             f['bbc'] = []
             for n in range(f['nbsets']):
-                data5_7 = data[cursor:cursor+3*f['nbfld'][n]].reshape((3, f['nbfld'][n]))
+                data7_7 = data[cursor:cursor+3*f['nbfld'][n]].reshape((f['nbfld'][n], 3)).T
                 cursor += 3*f['nbfld'][n]
                 keys = ['bcoil', 'plbfld', 'bbc']
                 for ikey, key in enumerate(keys):
-                    f[key].append(data5_7[ikey, :])
+                    f[key].append(data7_7[ikey, :])
 
             f['bcwgt'] = data[cursor]
             cursor += 1
 
         curs0 = cursor
-        keys = ['phidiam', 'delphid', 'nsets', 'nparts', 'nlim']
-        for ikey, key in enumerate(keys):
-            f[key] = data[curs0+ikey]
+        keys = {'phidiam':float, 'delphid':float, 'nsets':int, 'nparts':int, 'nlim':int}
+        for ikey, (key, type_id) in enumerate(keys.items()):
+            f[key] = type_id(data[curs0+ikey])
             cursor += 1
 
-        f['nsetsn'] = data[cursor:cursor+f['nsets']]
+        f['nsetsn'] = data[cursor:cursor+f['nsets']].astype(int)
         cursor += f['nsets']
 
         f['pfcspec'] = np.zeros((f['nparts'], max(f['nsetsn']), f['nsets']))
@@ -273,9 +308,50 @@ def read_vmec_txt(file_name):
                 cursor += 1
 
         curs0 = cursor
-        keys = ['nrgrid', 'nzgrid', 'tokid', 'rx1', 'rx2', 'zy1', 'zy2', 'conif', 'imatch_phiedge']
-        for ikey, key in enumerate(keys):
-            f[key] = data[curs0+ikey]
+        keys = {'nrgrid':int, 'nzgrid':int, 'tokid':float, 'rx1':float, 'rx2':float, 'zy1':float, 'zy2':float, 'conif':float, 'imatch_phiedge':float}
+        for ikey, (key, type_id) in enumerate(keys.items()):
+            f[key] = type_id(data[curs0+ikey])
             cursor += 1
 
+    if 'lrfplogical' not in f:
+        f['lrfplogical'] = 0
+
+    if 'xm_nyq' not in f:
+        f['xm_nyq'] = f['xm']
+
+    if 'xn_nyq' not in f:
+        f['xn_nyq'] = f['xn']
+
+    if 'mnmax_nyq' not in f:
+        f['mnmax_nyq'] = f['mnmax']
+
+    """
+    f = half2fullmesh(f)
+    """
+    
     return f
+
+
+def read_vmec_txt_data(file_name):
+    """
+    """
+    with open(file_name, 'r') as file:
+        flines = file.readlines()
+
+    version = float(flines[0].strip().split()[-1])
+    if ',' in flines[1]:
+        sep = ','
+        csv = True
+    else:
+        sep = None
+        csv = False
+
+    data = [version]
+    for line in flines[1:]:
+        for val in line.strip().split(sep=sep):
+            if not val.isalpha():
+                data.append(float(val))
+    data = np.array(data) # numpy array will be easier to manipulate
+
+    return data
+

--- a/lib/python/vmec/io.py
+++ b/lib/python/vmec/io.py
@@ -50,9 +50,6 @@ def read_vmec(file_name):
     if 'mnmax_nyq' not in f:
         f['mnmax_nyq'] = f['mnmax']
 
-    f['xn'] = -1 * f['xn']
-    f['xn_nyq'] = -1 * f['xn_nyq']
-
     for key in ['buco', 'bvco', 'vp', 'overr', 'specw']:
         f[key] = h2f(f[key])
     

--- a/lib/python/vmec/io.py
+++ b/lib/python/vmec/io.py
@@ -3,8 +3,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Adapted from pyFIDASIM/vmec_read.py
-    @author: micha
+read_vmec adapted from pyFIDASIM/vmec_read.py (author: micha) and matlabVMEC/VMEC/read_vmec.m (author: S. Lazerson)
 """
 
 import numpy as np
@@ -14,11 +13,10 @@ from scipy.io import netcdf
 def read_vmec(file_name):
     """
     """
-    try:
+    if file_name[-3:] == '.nc': # netCDF file
         f = netcdf.netcdf_file(file_name, mode='r', version=4)
-    except IOError:
-        print(f'File does not exist: {file_name}')
-        raise
+    else: # text file
+        f = read_vmec_txt(file_name)
 
     ns = f.variables['ns'].data
 
@@ -77,3 +75,207 @@ def read_vmec(file_name):
             'nyq_limit':nyq_limit, 'cos_keys':cos_keys, 'sin_keys':sin_keys,
             'cos_nyq_keys':cos_nyq_keys, 'sin_nyq_keys':sin_nyq_keys,
             'keys':['R', 'Z', 'Bs', 'Bv', 'Bu', 'dR_ds', 'dR_dv', 'dR_du', 'dZ_ds', 'dZ_dv', 'dZ_du']}
+
+
+def read_vmec_txt(file_name):
+    """
+    """
+    with open(file_name, 'r') as file:
+        flines = file.readlines()
+
+    version = float(flines[0].strip().split()[-1])
+    if ',' in flines[1]:
+        sep = ','
+        csv = True
+    else:
+        sep = None
+        csv = False
+
+    data = [version]
+    for line in flines[1:]:
+        for val in line.strip().split(sep=sep):
+            if not val.isalpha():
+                data.append(float(val))
+    data = np.array(data) # numpy array will be easier to manipulate
+
+    f = {}
+    cursor = 1
+    #if version > 6.5 and version <= 6.95:
+    f['lfreeb'] = 0
+    keys = ['wb', 'wp', 'gamma', 'pfac', 'rmax_surf', 'rmin_surf', 'zmax_surf', 'nfp', 'ns', 'mpol', 'ntor', 'mnmax', 'itfsq', 'niter', 'iasym', 'ireconstruct', 'ierr_vmec', 'imse', 'itse', 'nbsets', 'nobd', 'nextcur', 'nstore_seq']
+    for ikey, key in enumerate(keys):
+        f[key] = data[ikey+1]
+        cursor += 1
+
+    if f['ierr_vmec'] and f['ierr_vmec'] != 4:
+        raise Exception(f'ierr_vmec: {f["ierr_vmec"]}')
+
+    if f['nbsets'] > 0:
+        f['nbfld'] = data[cursor:cursor+f['nbsets']]
+        cursor += f['nbsets']
+
+    if f['iasym'] > 0:
+        d1_x, d2_x = 16, 14
+    else:
+        d1_x, d2_x = 13, 11
+    data1 = data[cursor:cursor+d1_x*f['mnmax']].reshape((d1_x, f['mnmax']))
+    cursor += d1_x*f['mnmax']
+    data2 = data[cursor:cursor+d2_x*f['mnmax']*(f['ns']-1)].reshape((d2_x, f['mnmax']*(f['ns']-1)))
+    cursor += d2_x*f['mnmax']*(f['ns']-1)
+
+    f['xm'] = data1[0, :].astype(int)
+    f['xn'] = data1[1, :].astype(int)
+
+    keys = ['rmnc', 'zmns', 'lmns', 'bmnc', 'gmnc', 'bsubumnc', 'bsubvmnc', 'bsubsmns', 'bsupumnc', 'bsupvmnc', 'currvmnc' ]
+    if f['iasym'] > 0:
+        keys.extend(['rmns', 'zmnc', 'lmnc'])
+    for ikey, key in enumerate(keys):
+        f[key] = np.vstack([data1[ikey+2, :], data2[ikey, :].reshape((f['mnmax'], f['ns'] - 1)).T]).T
+
+    data3 = data[cursor:cursor+13*(f['ns']-1)].reshape((13, f['ns']-1))
+    cursor += 13*(f['ns']-1)
+    keys = ['iotas', 'mass', 'pres', 'beta_vol', 'phip', 'buco', 'bvco', 'phi', 'vp', 'overr', 'jcuru', 'jcurv', 'specw']
+    for ikey, key in enumerate(keys):
+        f[key] = data3[ikey, :]
+
+    curs0 = cursor
+    keys = ['aspect', 'betatot', 'betapol', 'betator', 'betaxis', 'b0', 'isigna', 'input_extension', 'IonLarmor', 'VolAvgB', 'RBtor0', 'RBtor', 'Itor', 'Aminor', 'Rmajor', 'Volume']
+    for ikey, key in enumerate(keys):
+        f[key] = data[curs0+ikey]
+        cursor += 1
+    
+    data4 = data[cursor:cursor+6*(f['ns']-2)].reshape((6, f['ns']-2))
+    cursor += 6*(f['ns']-2)
+    keys = ['Dmerc', 'Dshear', 'Dwell', 'Dcurr', 'Dgeod', 'equif']
+    for ikey, key in enumerate(keys):
+        f[key] = data4[ikey, :]
+
+    f['curlabel'] = np.zeros(f['nextcur'])
+    if f['nextcur'] > 0:
+        f['lfreeb'] = 1
+        f['extcur'] = data[cursor:cursor+f['nextcur']]
+        cursor += f['nextcur']
+        """
+        Original matlabVMEC code:
+        fscanf(fid, '\n');
+        rem=f.nextcur;
+        j-0;
+        while rem > 0
+            line=fgetl(fid);
+            fscanf(fid, '\n')l
+            test=line(1);
+            index=findstr(line,test);
+            for i=1:size(index,2)/2;
+                f.curlabel{i+j}=strtrim(line(index(2*i-1)+1:index(2*i)-1));
+            end
+            j=j+size(index,2)/2;
+            rem=rem-size(index,2)/2;
+        end
+        """
+    data5 = data[cursor:cursor+4*f['nstore_seq']].reshape((4, f['nstore_seq']))
+    cursor += 4*f['nstore_seq']
+    keys = ['sqt', 'wdot', 'jdotb', 'bdotgradv']
+    for ikey, key in enumerate(keys):
+        f[key] = data5[ikey, :]
+
+    if f['ireconstruct'] > 0:
+        if f['imse'] >= 2 or f['itse'] > 0:
+            curs0 = cursor
+            keys = ['twsgt', 'msewgt', 'isnodes']
+            for ikey, key in enumerate(keys):
+                f[key] = data[curs0+ikey]
+                cursor += 1
+
+            data5_1 = data[cursor:cursor+3*f['isnodes']].reshape((3, f['isnodes']))
+            cursor += 3*f['isnodes']
+            keys = ['sknots', 'ystark', 'y2stark']
+            for ikey, key in enumerate(keys):
+                f[key] = data5_1[ikey, :]
+
+            f['ipnodes'] = data[cursor]
+            cursor += 1
+
+            data5_2 = data[cursor:cursor+3*f['ipnodes']].reshape((3, f['ipnodes']))
+            cursor += 3*f['ipnodes']
+            keys = ['pknots', 'ythom', 'y2thom']
+            for key, ikey in enumerate(keys):
+                f[key] = data5_2[ikey, :]
+
+            data5_3 = data[cursor:cursor+7*(2*f['ns']-1)].reshape((7, 2*f['ns']-1))
+            cursor += 7*(2*f['ns']-1)
+            keys = ['anglemse', 'rmid', 'qmid', 'shear', 'presmid', 'alfa', 'curmid']
+            for key, ikey in enumerate(keys):
+                f[key] = data5_3[ikey, :]
+
+            data5_4 = data[cursor:cursor+3*f['imse']].reshape((3, f['imse']))
+            cursor += 3*f['imse']
+            keys = ['rstark', 'datastark', 'qmeas']
+            for ikey, key in enumerate(keys):
+                f[key] = data5_4[ikey, :]
+
+            data5_5 = data[cursor:cursor+2*f['itse']].reshape((2, f['itse']))
+            cursor += 2*f['itse']
+            keys = ['trhom', 'datathom']
+            for ikey, key in enumerate(keys):
+                f[key] = data5_5[ikey, :]
+
+        if f['nobd'] > 0:
+            data5_6 = data[cursor:cursor+3*f['nobd']].reshape((3, f['nobd']))
+            cursor += 3*f['nobd']
+            keys = ['dsiext', 'plflux', 'fsiobt']
+            for ikey, key in enumerate(keys):
+                f[key] = data5_6[ikey, :]
+
+            f['flmwgt'] = data[cursor]
+            cursor += 1
+
+        nbfldn = f['nbfld'].sum()
+        if nbfldn > 0:
+            f['bcoil'] = []
+            f['plbfld'] = []
+            f['bbc'] = []
+            for n in range(f['nbsets']):
+                data5_7 = data[cursor:cursor+3*f['nbfld'][n]].reshape((3, f['nbfld'][n]))
+                cursor += 3*f['nbfld'][n]
+                keys = ['bcoil', 'plbfld', 'bbc']
+                for ikey, key in enumerate(keys):
+                    f[key].append(data5_7[ikey, :])
+
+            f['bcwgt'] = data[cursor]
+            cursor += 1
+
+        curs0 = cursor
+        keys = ['phidiam', 'delphid', 'nsets', 'nparts', 'nlim']
+        for ikey, key in enumerate(keys):
+            f[key] = data[curs0+ikey]
+            cursor += 1
+
+        f['nsetsn'] = data[cursor:cursor+f['nsets']]
+        cursor += f['nsets']
+
+        f['pfcspec'] = np.zeros((f['nparts'], max(f['nsetsn']), f['nsets']))
+        for k in range(f['nsets']):
+            for j in range(f['nsetsn'][k]):
+                for i in range(f['nparts']):
+                        f['pfcspec'][i, j, k] = data[cursor]
+                        cursor += 1
+
+        f['limitr'] = data[cursor:cursor+f['nlim']]
+        cursor += f['nlim']
+        keys = ['rlim', 'zlim']
+        for key in keys:
+            f[key] = np.zeros((max(f['limitr']), f['nlim']))
+        for j in range(f['nlim']):
+            for i in range(f['limitr'][j]):
+                f['rlim'][i, j] = data[cursor]
+                cursor += 1
+                f['zlim'][i, j] = data[cursor]
+                cursor += 1
+
+        curs0 = cursor
+        keys = ['nrgrid', 'nzgrid', 'tokid', 'rx1', 'rx2', 'zy1', 'zy2', 'conif', 'imatch_phiedge']
+        for ikey, key in enumerate(keys):
+            f[key] = data[curs0+ikey]
+            cursor += 1
+
+    return f

--- a/lib/python/vmec/io.py
+++ b/lib/python/vmec/io.py
@@ -1,0 +1,79 @@
+#!/bin/sh
+"exec" "$FIDASIM_DIR/deps/python" "$0" "$@"
+# -*- coding: utf-8 -*-
+
+"""
+Adapted from pyFIDASIM/vmec_read.py
+    @author: micha
+"""
+
+import numpy as np
+
+from scipy.io import netcdf
+
+def read_vmec(file_name):
+    """
+    """
+    try:
+        f = netcdf.netcdf_file(file_name, mode='r', version=4)
+    except IOError:
+        print(f'File does not exist: {file_name}')
+        raise
+
+    ns = f.variables['ns'].data
+
+    xm = f.variables['xm'].data
+    xn = f.variables['xn'].data
+    md = len(xm)
+
+    xm_nyq = f.variables['xm_nyq'].data
+    xn_nyq = f.variables['xn_nyq'].data
+    md_nyq = len(xm_nyq)
+
+    ds = 1. / (ns - 1)
+
+    fourierAmps = {
+            'R'        : f.variables['rmnc'].data,
+            'Z'        : f.variables['zmns'].data,
+            'Lambda'   : f.variables['lmns'].data,
+            'Bu'       : f.variables['bsubumnc'].data,
+            'Bv'       : f.variables['bsubvmnc'].data,
+            'Bs'       : f.variables['bsubsmns'].data,
+            'Bmod'     : f.variables['bmnc'].data,
+            'Jacobian' : f.variables['gmnc'].data,
+            'dR_ds'    : np.gradient(f.variables['rmnc'].data, ds, axis=0),
+            'dR_du'    : -f.variables['rmnc'].data * xm,
+            'dR_dv'    : f.variables['rmnc'].data * xn,
+            'dZ_ds'    : np.gradient(f.variables['zmns'].data, ds, axis=0),
+            'dZ_du'    : f.variables['zmns'].data * xm,
+            'dZ_dv'    : -f.variables['zmns'].data * xn
+            }
+    
+    if md == md_nyq:
+        nyq_limit = False
+
+        cos_keys = ['R', 'Jacobian', 'Bu', 'Bv', 'Bmod']
+        sin_keys = ['Z', 'Lambda', 'Bs']
+
+        cos_nyq_keys = []
+        sin_nyq_keys = []
+    else:
+        nyq_limit = True
+
+        cos_keys = ['R', 'Jacobian']
+        sin_keys = ['Z', 'Lambda']
+
+        cos_nyq_keys = ['Bu', 'Bv', 'Bmod']
+        sin_nyq_keys = ['Bs']
+
+    cos_keys.extend(['dR_ds', 'dZ_du', 'dZ_dv'])
+    sin_keys.extend(['dR_du', 'dR_dv', 'dZ_ds'])
+
+    f.close()
+
+    return {'fourierAmps':fourierAmps,
+            'ns':ns, 'xm':xm, 'xn':xn, 'md':md,
+            'xm_nyq':xm_nyq, 'xn_nyq':xn_nyq, 'md_nyq':md_nyq,
+            'nyq_limit':nyq_limit, 'cos_keys':cos_keys, 'sin_keys':sin_keys,
+            'cos_nyq_keys':cos_nyq_keys, 'sin_nyq_keys':sin_nyq_keys,
+            'keys':['R', 'Z', 'Bs', 'Bv', 'Bu', 'dR_ds', 'dR_dv', 'dR_du', 'dZ_ds', 'dZ_dv', 'dZ_du']}

--- a/lib/python/vmec/utils.py
+++ b/lib/python/vmec/utils.py
@@ -44,10 +44,10 @@ def fourier_transform_3D(wout, ntheta=16, nphi=20, thetamin=None, thetamax=None,
     new_wout = wout.copy()
     if (thetamin is None and thetamax is None) or np.isclose([thetamin, thetamax], [0, 2*np.pi], atol=0.5*np.pi/180).all():
         thetamin = 0
-        thetamax = 2*np.pi * (1 - 1/ntheta) # Removes double counting 0 (2*pi)
+        thetamax = 2*np.pi # Removes double counting 0 (2*pi)
     if (phimin is None and phimax is None) or np.isclose([phimin, phimax], [0, 2*np.pi], atol=0.5*np.pi/180).all():
         phimin = 0
-        phimax = 2*np.pi * (1 - 1/nphi)
+        phimax = 2*np.pi
 
     theta = np.linspace(thetamin, thetamax, ntheta)
     phi = np.linspace(phimin, phimax, nphi)

--- a/lib/python/vmec/utils.py
+++ b/lib/python/vmec/utils.py
@@ -2,6 +2,11 @@
 "exe" "$FIDASIM_DIR/deps/python" "$0" "$@"
 # -*- coding: utf-8 -*-
 
+"""
+fourier_transform_3D and Brzp_transform adapted from pyFIDASIM/vmec_read.py
+    @author: micha
+"""
+
 import numpy as np
 
 def fourier_transform_3D(vmec, ntheta=5, nphi=10, thetamin=0, thetamax=2*np.pi, phimin=0, phimax=2*np.pi):

--- a/lib/python/vmec/utils.py
+++ b/lib/python/vmec/utils.py
@@ -90,7 +90,7 @@ def fourier_transform_3D(wout, ntheta=16, nphi=20, thetamin=None, thetamax=None,
 
     return new_wout
 
-def Brzp_transform(wout, cc_in_out=None, nrgrid=61, nzgrid=25):
+def Brzp_transform(wout, cc_in_out=None, nrgrid=41, nzgrid=25):
     """
     #+#Brzp_transform
     #+ Converts B(s,v,u) to B(R,Z,tor)

--- a/lib/python/vmec/utils.py
+++ b/lib/python/vmec/utils.py
@@ -1,0 +1,61 @@
+#!/bin/sh
+"exe" "$FIDASIM_DIR/deps/python" "$0" "$@"
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+def fourier_transform_3D(vmec, ntheta=5, nphi=10, thetamin=0, thetamax=2*np.pi, phimin=0, phimax=2*np.pi):
+    theta = np.linspace(thetamin, thetamax, ntheta)
+    phi = np.linspace(phimin, phimax, nphi)
+
+    pol, tor = np.meshgrid(theta, phi)
+    pol_xm = np.dot(vmec['xm'].reshape(vmec['md'], 1), pol.reshape(1, nphi * ntheta))
+    tor_xn = np.dot(vmec['xn'].reshape(vmec['md'], 1), tor.reshape(1, nphi * ntheta))
+
+    cos_mu_nv = np.cos(pol_xm - tor_xn)
+    sin_mu_nv = np.sin(pol_xm - tor_xn)
+
+    if vmec['nyq_limit']:
+        for key in vmec['keys']:
+            if key in vmec['cos_nyq_keys'] or key in vmec['sin_nyq_keys']:
+                pol_nyq_xm = np.dot(vmec['xm_nyq'].reshape(vmec['md_nyq'], 1), pol.reshape(1, nphi * ntheta))
+                tor_nyq_xn = np.dot(vmec['xn_nyq'].reshape(vmec['md_nyq'], 1), pol.reshape(1, nphi * ntheta))
+
+                cos_nyq_mu_nv = np.cos(pol_nyq_xm - tor_nyq_xn)
+                sin_nyq_my_nv = np.sin(pol_nyq_xm - tor_nyq_xn)
+
+    invFourAmps = {}
+    for key in vmec['keys']:
+        if key in vmec['cos_keys']:
+            invFourAmps[key] = np.dot(vmec['fourierAmps'][key], cos_mu_nv).reshape(vmec['ns'], nphi, ntheta)
+        elif key in vmec['sin_keys']:
+            invFourAmps[key] = np.dot(vmec['fourierAmps'][key], sin_mu_nv).reshape(vmec['ns'], nphi, ntheta)
+        elif vmec['nyq_limit'] and key in vmec['cos_nyq_keys']:
+            invFourAmps[key] = np.dot(vmec['fourierAmps'][key], cos_nyq_mu_nv).reshape(vmec['ns'], nphi, ntheta)
+        elif vmec['nyq_limit'] and key in vmec['sin_nyq_keys']:
+            invFourAmps[key] = np.dot(vmec['fourierAmps'][key], sin_nyq_mu_nv).reshape(vmec['ns'], nphi, ntheta)
+        else:
+            raise NameError(f'key = "{key}" is not available')
+
+    return invFourAmps
+
+def Brzp_transform(invFourAmps):
+    Bs = invFourAmps['Bs']
+    Bv = invFourAmps['Bv']
+    Bu = invFourAmps['Bu']
+
+    R= invFourAmps['R']
+    dR_ds = invFourAmps['dR_ds']
+    dR_dv = invFourAmps['dR_dv']
+    dR_du = invFourAmps['dR_du']
+
+    dZ_ds = invFourAmps['dZ_ds']
+    dZ_dv = invFourAmps['dZ_dv']
+    dZ_du = invFourAmps['dZ_du']
+
+    B_norm = 1. / (dR_ds * dZ_du - dR_du * dZ_ds)
+    Br = (dZ_du * Bs - dZ_ds * Bu) * B_norm
+    Bp = ( ( ( Bs * (dR_du * dZ_dv - dR_dv * dZ_du) + Bu * (dR_dv * dZ_ds - dR_ds * dZ_dv) ) * B_norm ) + Bv ) / R
+    Bz = (dR_ds * Bu - dR_du * Bs) * B_norm
+    
+    return {'Br':Br, 'Bz':Bz, 'Bp':Bp}

--- a/lib/python/vmec/utils.py
+++ b/lib/python/vmec/utils.py
@@ -9,58 +9,171 @@ fourier_transform_3D and Brzp_transform adapted from pyFIDASIM/vmec_read.py
 
 import numpy as np
 
-def fourier_transform_3D(vmec, ntheta=5, nphi=10, thetamin=0, thetamax=2*np.pi, phimin=0, phimax=2*np.pi):
+from scipy.interpolate import griddata
+
+def fourier_transform_3D(wout, ntheta=16, nphi=20, thetamin=None, thetamax=None, phimin=None, phimax=None):
+    """
+    """
+    new_wout = wout.copy()
+    if (thetamin is None and thetamax is None) or np.isclose([thetamin, thetamax], [0, 2*np.pi], atol=0.5*np.pi/180).all():
+        thetamin = 0
+        thetamax = 2*np.pi * (1 - 1/ntheta) # Removes double counting 0 (2*pi)
+    if (phimin is None and phimax is None) or np.isclose([phimin, phimax], [0, 2*np.pi], atol=0.5*np.pi/180).all():
+        phimin = 0
+        phimax = 2*np.pi * (1 - 1/nphi)
+
     theta = np.linspace(thetamin, thetamax, ntheta)
     phi = np.linspace(phimin, phimax, nphi)
 
     pol, tor = np.meshgrid(theta, phi)
-    pol_xm = np.dot(vmec['xm'].reshape(vmec['md'], 1), pol.reshape(1, nphi * ntheta))
-    tor_xn = np.dot(vmec['xn'].reshape(vmec['md'], 1), tor.reshape(1, nphi * ntheta))
+    pol_xm = np.dot(new_wout['xm'].reshape(new_wout['md'], 1), pol.reshape(1, nphi * ntheta))
+    tor_xn = np.dot(new_wout['xn'].reshape(new_wout['md'], 1), tor.reshape(1, nphi * ntheta))
 
     cos_mu_nv = np.cos(pol_xm - tor_xn)
     sin_mu_nv = np.sin(pol_xm - tor_xn)
 
-    if vmec['nyq_limit']:
-        for key in vmec['keys']:
-            if key in vmec['cos_nyq_keys'] or key in vmec['sin_nyq_keys']:
-                pol_nyq_xm = np.dot(vmec['xm_nyq'].reshape(vmec['md_nyq'], 1), pol.reshape(1, nphi * ntheta))
-                tor_nyq_xn = np.dot(vmec['xn_nyq'].reshape(vmec['md_nyq'], 1), pol.reshape(1, nphi * ntheta))
+    if new_wout['nyq_limit']:
+        for key in new_wout['keys']:
+            if key in new_wout['cos_nyq_keys'] or key in new_wout['sin_nyq_keys']:
+                pol_nyq_xm = np.dot(new_wout['xm_nyq'].reshape(new_wout['md_nyq'], 1), pol.reshape(1, nphi * ntheta))
+                tor_nyq_xn = np.dot(new_wout['xn_nyq'].reshape(new_wout['md_nyq'], 1), pol.reshape(1, nphi * ntheta))
 
                 cos_nyq_mu_nv = np.cos(pol_nyq_xm - tor_nyq_xn)
-                sin_nyq_my_nv = np.sin(pol_nyq_xm - tor_nyq_xn)
+                sin_nyq_mu_nv = np.sin(pol_nyq_xm - tor_nyq_xn)
 
-    invFourAmps = {}
-    for key in vmec['keys']:
-        if key in vmec['cos_keys']:
-            invFourAmps[key] = np.dot(vmec['fourierAmps'][key], cos_mu_nv).reshape(vmec['ns'], nphi, ntheta)
-        elif key in vmec['sin_keys']:
-            invFourAmps[key] = np.dot(vmec['fourierAmps'][key], sin_mu_nv).reshape(vmec['ns'], nphi, ntheta)
-        elif vmec['nyq_limit'] and key in vmec['cos_nyq_keys']:
-            invFourAmps[key] = np.dot(vmec['fourierAmps'][key], cos_nyq_mu_nv).reshape(vmec['ns'], nphi, ntheta)
-        elif vmec['nyq_limit'] and key in vmec['sin_nyq_keys']:
-            invFourAmps[key] = np.dot(vmec['fourierAmps'][key], sin_nyq_mu_nv).reshape(vmec['ns'], nphi, ntheta)
+    inverse_fourier_amps = {}
+    for key in new_wout['keys']:
+        if key in new_wout['cos_keys']:
+            inverse_fourier_amps[key] = np.dot(new_wout['fourier_amps'][key], cos_mu_nv).reshape(new_wout['ns'], nphi, ntheta)
+        elif key in new_wout['sin_keys']:
+            inverse_fourier_amps[key] = np.dot(new_wout['fourier_amps'][key], sin_mu_nv).reshape(new_wout['ns'], nphi, ntheta)
+        elif new_wout['nyq_limit'] and key in new_wout['cos_nyq_keys']:
+            inverse_fourier_amps[key] = np.dot(new_wout['fourier_amps'][key], cos_nyq_mu_nv).reshape(new_wout['ns'], nphi, ntheta)
+        elif new_wout['nyq_limit'] and key in new_wout['sin_nyq_keys']:
+            inverse_fourier_amps[key] = np.dot(new_wout['fourier_amps'][key], sin_nyq_mu_nv).reshape(new_wout['ns'], nphi, ntheta)
         else:
             raise NameError(f'key = "{key}" is not available')
 
-    return invFourAmps
+    new_wout.update({
+        'inverse_fourier_amps':inverse_fourier_amps,
+        'ntheta':ntheta, 'thetamin':thetamin, 'thetamax':thetamax,
+        'nphi':nphi, 'phimin':phimin, 'phimax':phimax,
+        'theta':theta, 'phi':phi
+        })
 
-def Brzp_transform(invFourAmps):
-    Bs = invFourAmps['Bs']
-    Bv = invFourAmps['Bv']
-    Bu = invFourAmps['Bu']
+    return new_wout
 
-    R= invFourAmps['R']
-    dR_ds = invFourAmps['dR_ds']
-    dR_dv = invFourAmps['dR_dv']
-    dR_du = invFourAmps['dR_du']
+def Brzp_transform(wout, cc_in_out=None):
+    """
+    """
+    new_wout = wout.copy()
+    if cc_in_out:
+        if isinstance(cc_in_out, (tuple, list, np.ndarray)) and len(cc_in_out) == 2:
+            new_wout = convert_COCOS_VMEC(new_wout, cc_in_out)
+        else:
+            raise ValueError(f'cc_in_out must be a list-like object of length 2\n{cc_in_out=}')
+        
+    inverse_fourier_amps = new_wout['inverse_fourier_amps']
 
-    dZ_ds = invFourAmps['dZ_ds']
-    dZ_dv = invFourAmps['dZ_dv']
-    dZ_du = invFourAmps['dZ_du']
+    Bs = inverse_fourier_amps['Bs']
+    Bv = inverse_fourier_amps['Bv']
+    Bu = inverse_fourier_amps['Bu']
 
-    B_norm = 1. / (dR_ds * dZ_du - dR_du * dZ_ds)
+    R = inverse_fourier_amps['R']
+    dR_ds = inverse_fourier_amps['dR_ds']
+    dR_dv = inverse_fourier_amps['dR_dv']
+    dR_du = inverse_fourier_amps['dR_du']
+
+    dZ_ds = inverse_fourier_amps['dZ_ds']
+    dZ_dv = inverse_fourier_amps['dZ_dv']
+    dZ_du = inverse_fourier_amps['dZ_du']
+
+    B_norm = np.zeros_like(R)
+    denom = dR_ds * dZ_du - dR_du * dZ_ds
+    nz = np.where(denom != 0)
+    B_norm[nz] = 1. / denom[nz]
+
     Br = (dZ_du * Bs - dZ_ds * Bu) * B_norm
-    Bp = ( ( ( Bs * (dR_du * dZ_dv - dR_dv * dZ_du) + Bu * (dR_dv * dZ_ds - dR_ds * dZ_dv) ) * B_norm ) + Bv ) / R
     Bz = (dR_ds * Bu - dR_du * Bs) * B_norm
-    
-    return {'Br':Br, 'Bz':Bz, 'Bp':Bp}
+    Bt = ( ( ( Bs * (dR_du * dZ_dv - dR_dv * dZ_du) + Bu * (dR_dv * dZ_ds - dR_ds * dZ_dv) ) * B_norm ) + Bv ) / R
+
+    new_wout.update({
+        'Br':Br,
+        'Bz':Bz,
+        'Bt':Bt
+        })
+
+    return new_wout
+
+def map_B_and_rho(wout, nrgrid=41, nzgrid=25):
+    """
+    """
+    new_wout = wout.copy()
+    inverse_fourier_amps = new_wout['inverse_fourier_amps']
+
+    R = inverse_fourier_amps['R']
+    Z = inverse_fourier_amps['Z']
+    ns = new_wout['ns']
+
+    S = np.zeros([ns, new_wout['ntheta']])
+    for i in range(new_wout['ntheta']):
+        S[:, i] = new_wout['s_dom']
+
+    idx = np.arange(0, ns-1)
+    brzphi_grid = np.zeros([nrgrid, nzgrid, 3, new_wout['nphi']])
+    rho_grid = np.zeros([nrgrid, nzgrid, new_wout['nphi']])
+
+    rmin = R.min()
+    rmax = R.max()
+    zmin = Z.min()
+    zmax = Z.max()
+    rgrid, zgrid = np.mgrid[rmin:rmax:complex(nrgrid), zmin:zmax:complex(nzgrid)]
+    rarr, zarr = rgrid[:, 0], zgrid[0, :]
+    #rarr, zarr = np.zeros((nrgrid, new_wout['nphi'])), np.zeros((nzgrid, new_wout['nphi']))
+
+
+    for iphi in range(new_wout['nphi']):
+        """
+        rmin = R[:, iphi, :].min()
+        rmax = R[:, iphi, :].max()
+        zmin = Z[:, iphi, :].min()
+        zmax = Z[:, iphi, :].max()
+        rgrid, zgrid = np.mgrid[rmin:rmax:complex(nrgrid), zmin:zmax:complex(nzgrid)]
+        rarr[:, iphi] = rgrid[:, 0]
+        zarr[:, iphi] = zgrid[0, :]
+        """
+
+        rzdata = np.array([R[:, iphi, :].flatten(), Z[:, iphi, :].flatten()]).T
+        rho_grid[:, :, iphi] = np.sqrt(griddata(rzdata, S.flatten(), (rgrid, zgrid), fill_value=0))
+
+        idx = np.arange(1, ns, 1)
+        rzdata = np.array([R[idx, iphi, :].flatten(), Z[idx, iphi, :].flatten()]).T
+        for ib, bkey in enumerate(['Br', 'Bz', 'Bt']):
+            brzphi_grid[:, :, ib, iphi] = griddata(rzdata, new_wout[bkey][idx, iphi, :].flatten(), (rgrid, zgrid), fill_value=0)
+
+    new_wout.update({
+        'brzphi_grid':brzphi_grid,
+        'rho_grid':rho_grid,
+        'rarr':rarr, 'zarr':zarr
+        })
+
+    return new_wout
+
+def convert_COCOS_VMEC(wout, cc_in_out):
+    """
+    """
+    inverse_fourier_amps = wout['inverse_fourier_amps']
+    new_inverse_fourier_amps = {key:val for key, val in inverse_fourier_amps.items() if key not in ['Bs', 'Bv', 'Bu']}
+    new_wout = {key:val for key, val in wout.items() if key != 'inverse_fourier_amps'}
+
+    cc_in, cc_out = cc_in_out
+    sigma_RphZ_out = -1 if cc_in % 2 == 0 else 1
+    sigma_RphZ_in = -1 if cc_in % 2 == 0 else 1
+    sigma_RphZ_eff = sigma_RphZ_out * sigma_RphZ_in
+
+    new_inverse_fourier_amps['Bs'] = inverse_fourier_amps['Bs'] * sigma_RphZ_eff # B_rho, radial-like component
+    new_inverse_fourier_amps['Bv'] = inverse_fourier_amps['Bv'] * sigma_RphZ_eff # B_phi, toroidal-like component
+    new_inverse_fourier_amps['Bu'] = inverse_fourier_amps['Bu'] * sigma_RphZ_eff # B_theta, poloidal-like component
+
+    new_wout['inverse_fourier_amps'] = new_inverse_fourier_amps
+    return new_wout

--- a/lib/python/vmec/utils.py
+++ b/lib/python/vmec/utils.py
@@ -42,11 +42,20 @@ def fourier_transform_3D(wout, ntheta=16, nphi=20, thetamin=None, thetamax=None,
     #+```
     """
     new_wout = wout.copy()
-    if (thetamin is None and thetamax is None) or np.isclose([thetamin, thetamax], [0, 2*np.pi], atol=0.5*np.pi/180).all():
+    if (thetamin is None and thetamax is None) or (thetamin < 0 and thetamax > 2*np.pi) or (thetamin > thetamax):
         thetamin = 0
-        thetamax = 2*np.pi # Removes double counting 0 (2*pi)
-    if (phimin is None and phimax is None) or np.isclose([phimin, phimax], [0, 2*np.pi], atol=0.5*np.pi/180).all():
+        thetamax = 2*np.pi
+    if thetamin is None or thetamin < 0:
+        thetamin = 0
+    if thetamax is None or thetamax > 2*np.pi:
+        thetamax = 2*np.pi
+
+    if (phimin is None and phimax is None) or (phimin < 0 and phimax < 2*np.pi) or (phimin > phimax):
         phimin = 0
+        phimax = 2*np.pi
+    if phimin is None or phimin < 0:
+        phimin = 0
+    if phimax is None or phimax > 2*np.pi:
         phimax = 2*np.pi
 
     theta = np.linspace(thetamin, thetamax, ntheta)

--- a/lib/python/vmec/utils.py
+++ b/lib/python/vmec/utils.py
@@ -112,7 +112,7 @@ def Brzp_transform(wout, cc_in_out=None, nrgrid=61, nzgrid=25):
     #+```python
     #+>>> wout = read_vmec(file_name)
     #+>>> new_wout = fourier_transform_3D(wout)
-    #+>>> new_new_wout = Brzp_transform(wout, cc_in_out=(3,5), nrgrid=61, nzgrid=25)
+    #+>>> new_new_wout = Brzp_transform(new_wout, cc_in_out=(3,5), nrgrid=61, nzgrid=25)
     #+```
     """
     new_wout = wout.copy()
@@ -181,7 +181,8 @@ def Brzp_transform(wout, cc_in_out=None, nrgrid=61, nzgrid=25):
 
     new_wout.update({
         'rho_grid':rho_grid,
-        'R':rarr, 'Z':zarr
+        'R':rarr, 'Z':zarr,
+        'nr':rarr.size, 'nz':zarr.size
         })
 
     return new_wout
@@ -219,9 +220,9 @@ def convert_COCOS_VMEC(wout, cc_in_out):
 
     return new_wout
 
-def wout_to_fields(wout, time=None, er=None, ez=None, et=None):
+def fields_from_wout(wout, time=None, er=None, ez=None, et=None):
     """
-    #+#wout_to_fields
+    #+#fields_from_wout
     #+ Extracts field components from `wout` into FIDASIM-readable fields object
     #+***
     #+##Input Arguments
@@ -237,12 +238,14 @@ def wout_to_fields(wout, time=None, er=None, ez=None, et=None):
     #+    **et**: E-field toroidal component
     #+
     #+##Output Arguments
-    #+    **new_wout**: VMEC dictionary
+    #+    **fields**: FIDASIM fields dictionary
     #+
     #+##Example Usage
     #+```python
     #+>>> wout = read_vmec(file_name)
-    #+>>> new_wout = convert_COCOS_VMEC(wout, cc_in_out=(3,5))
+    #+>>> new_wout = fourier_transform_3D(wout)
+    #+>>> new_new_wout = Brzp_transform(new_wout, cc_in_out=(3,5), nrgrid=61, nzgrid=25)
+    #+>>> fields = fields_from_wout(new_new_wout, time=0, er=None, ez=None, et=None)
     #+```
     """
     if time is None:
@@ -269,3 +272,29 @@ def wout_to_fields(wout, time=None, er=None, ez=None, et=None):
             'data_source':data_source,
             'br':br, 'bz':bz, 'bt':bt,
             'er':er, 'ez':ez, 'et':et}
+
+def grid_from_wout(wout):
+    """
+    #+#grid_from_wout
+    #+ Extracts interpolation grid from `wout` into FIDASIM-readable igrid object
+    #+***
+    #+##Input Arguments
+    #+    **wout**: VMEC dictionary
+    #+
+    #+##Output Arguments
+    #+    **igrid**: FIDASIM igrid dictionary
+    #+
+    #+##Example Usage
+    #+```python
+    #+>>> wout = read_vmec(file_name)
+    #+>>> new_wout = fourier_transform_3D(wout)
+    #+>>> new_new_wout = Brzp_transform(new_wout, cc_in_out=(3,5), nrgrid=61, nzgrid=25)
+    #+>>> igrid = grid_from_wout(new_new_wout)
+    #+```
+    """
+    r, z, phi = wout['R'], wout['Z'], wout['phi']
+    nr, nz, nphi = wout['nr'], wout['nz'], wout['nphi']
+    z2d, r2d = np.mesgrid(z, r)
+    return {'r':r, 'z':z, 'phi':phi,
+            'nr':nr, 'nz':nz, 'nphi':nphi,
+            'r2d':r2d, 'z2d':z2d}


### PR DESCRIPTION
Added VMEC `.wout` file io for text and NETCDF files.
Added utils to convert to FIDASIM fields and igrid objects.
Validated against LHD case (GNET-FIDASIM) using VMEC version 6.90.
<img width="1188" alt="VMEC_to_GNETFIDASIM_comparison" src="https://github.com/user-attachments/assets/d991d9ad-65f9-49b5-95f6-cb6403ae3809">

### **Important**
1. Compatibility with other versions and with NETCDF files still needs to be validated.
2. COCOS numbers should be considered when using the utils/Brzp_transform function.
    - It might help to have a lookup table in the documentation for COCOS numbers for various devices. From what I gather, LHD uses COCOS 8