### PR TITLE
Closes Issue #276

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# November 2024: Commit number 0688d4cab69afdb22071f8e46262612b0ac200a7
+- Changed counter to int64 to avoid overflows issues
+- Added gyrocenter positions to output file when `n_(p)npa > 1`
+- Updated documentation

--- a/docs/user-guide/03_technical/01_prefida_inputs.md
+++ b/docs/user-guide/03_technical/01_prefida_inputs.md
@@ -70,15 +70,18 @@ The following settings provide a good balance between runtime and Monte Carlo no
 
 |       Variable      |   Type  | Rank | Dimensions | Units |               Description                |
 |:-------------------:|:-------:|:----:|:----------:|:-----:|:-----------------------------------------|
-| `n_fida`            | Int32   | 0    | NA         | NA    | Number of FIDA MC particles              |
-| `n_pfida`           | Int32   | 0    | NA         | NA    | Number of passive FIDA MC particles      |
-| `n_npa`             | Int32   | 0    | NA         | NA    | Number of NPA MC particles               |
-| `n_pnpa`            | Int32   | 0    | NA         | NA    | Number of passive NPA MC particles       |
-| `n_nbi`             | Int32   | 0    | NA         | NA    | Number of NBI MC particles               |
-| `n_halo`            | Int32   | 0    | NA         | NA    | Number of HALO MC particles              |
-| `n_dcx`             | Int32   | 0    | NA         | NA    | Number of DCX MC particles               |
-| `n_birth`           | Int32   | 0    | NA         | NA    | Number of Birth particles outputed       |
-
+| `n_fida`            | Int64   | 0    | NA         | NA    | Number of FIDA MC particles              |
+| `n_pfida`           | Int64   | 0    | NA         | NA    | Number of passive FIDA MC particles      |
+| `n_npa`             | Int64   | 0    | NA         | NA    | Number of NPA MC particles               |
+| `n_pnpa`            | Int64   | 0    | NA         | NA    | Number of passive NPA MC particles       |
+| `n_nbi`             | Int64   | 0    | NA         | NA    | Number of NBI MC particles               |
+| `n_halo`            | Int64   | 0    | NA         | NA    | Number of HALO MC particles              |
+| `n_dcx`             | Int64   | 0    | NA         | NA    | Number of DCX MC particles               |
+| `n_birth`           | Int64   | 0    | NA         | NA    | Number of Birth particles outputed       |
+###NPA switch
+* `n_npa == 0`: Will deactivate the NPA calculation
+* `n_npa == 1`: Will perform the NPA calculation but just store as output the flux (per unit of energy) of neutral particle arriving to the detector
+* `n_npa == 2`: Will do the same of `n_npa == 1` but will also save the initial position and velocity (Energy and pitch) of each neutral marker. Since Nov 2024, the position and energy of the gyrocenter is also saved, if the used fast-ion distribution as input is symmetric in toroidal angle
 ##Neutral Beam Settings
 These variables define the neutral beam properties.
 Currently the mass of the beam species, `ab`, can only be the mass either protium or deuterium.

--- a/docs/user-guide/03_technical/04_outputs.md
+++ b/docs/user-guide/03_technical/04_outputs.md
@@ -1,0 +1,39 @@
+title: FIDASIM Outputs
+
+This page documents FIDASIMs Outputs. It is under constructions
+
+[TOC]
+
+---
+# NPA Outputs
+The npa output file is: `<runID>_npa.h5`. This file is only created if `n_npa > 0` or if `n_pnpa > 0`
+
+It contains:
+
+|       Variable      | Present if |  Type   | Rank | Dimensions | Units |               Description                |
+|:-------------------:|:----------:|:-------:|:----:|:----------:|:-----:|:-----------------------------------------|
+| `count`             | `n_npa > 0`| Int32   | 1    | NA         | NA    | Number of active markers that hit the detector: count(chan)|
+| `pcount`            | `n_pnpa > 0`| Int32   | 1    | NA         | NA    | Number of passive markers that hit the detector: count(chan)|
+| `energy`            | `n_npa > 0`| Float64 | 1    | nE         | keV   | Energy axis where the NPA flux is binned |
+| `flux`              | `n_npa > 0`| Float64 | 2    | nE, nchan  | #/(s*keV)| Active Neutral flux: flux(energy,chan)   |
+| `pflux`             | `n_pnpa > 0`| Float64 | 2    | nE, nchan  | #/(s*keV)| Passive Neutral flux: flux(energy,chan)   |
+| `nchan `            | `n_(p)npa > 0`| Int32   | 0    | NA         | NA    | Number of channels     |
+| `nenergy `          | `n_(p)npa > 0`| Int32   | 0    | NA         | NA    | Number of energies     |
+| `radius`            | `n_(p)npa > 0`| Float64 | 1    | nchan      | m     | Detector LOS radius at midplane or tangency point     |
+| `particles`         | `n_npa > 1`|  Structure| NA   | NA         | NA    | Data from the active markers, see below           |
+| `passive_particles` | `n_pnpa > 1`| Structure   | NA    | NA         | NA    | Data from the passive markers, see below      |
+
+If the NPA switch is greater than 1, the `particle` or `passive_particle` structure is also output in the file, it contains, in both cases:
+
+|       Variable      | Present if    |  Type   | Rank | Dimensions | Units |               Description                |
+|:-------------------:|:-------------:|:-------:|:----:|:----------:|:-----:|:-----------------------------------------|
+| `nparticle`         | `n_(p)npa > 1`| Int32   | 0    | NA         | NA    | Number of markers that hit the detector|
+| `class`             | `n_(p)npa > 1`| Int32   | 1    | nMarker    | NA    | Class of the neutral particle |
+| `detector`          | `n_(p)npa > 1`| Int32   | 1    | nMarker    | NA    | Detector (channel) the marker hit|
+| `energy`            | `n_(p)npa > 1`| Float64 | 1    | nMarker    | keV   | Energy of the particle |
+| `gci`               | `n_(p)npa > 1`| Float64 | 2    | 3, nMarker | m     | Neutral particle's gyrocenter birth position in machine coordinates: gci([x,y,z],particle)|
+| `ri`                | `n_(p)npa > 1`| Float64 | 2    | 3, nMarker | m     | Neutral particle's birth position in machine coordinates: ri([x,y,z],particle)|
+| `rf`                | `n_(p)npa > 1`| Float64 | 2    | 3, nMarker | m     | Neutral particle's hit position in machine coordinates: rf([x,y,z],particle)|
+| `pitch`             | `n_(p)npa > 1`| Float64 | 1    | nMarker    | NA    | Pitch value of the neutral particle: p = v_parallel/v w.r.t. the magnetic field   |
+| `weight`            | `n_(p)npa > 1`| Float64 | 1    | nMarker    | #/s   | Neutral particle's contribution to the flux |
+

--- a/docs/user-guide/03_technical/04_outputs.md
+++ b/docs/user-guide/03_technical/04_outputs.md
@@ -31,9 +31,9 @@ If the NPA switch is greater than 1, the `particle` or `passive_particle` struct
 | `class`             | `n_(p)npa > 1`| Int32   | 1    | nMarker    | NA    | Class of the neutral particle |
 | `detector`          | `n_(p)npa > 1`| Int32   | 1    | nMarker    | NA    | Detector (channel) the marker hit|
 | `energy`            | `n_(p)npa > 1`| Float64 | 1    | nMarker    | keV   | Energy of the particle |
-| `gci`               | `n_(p)npa > 1`| Float64 | 2    | 3, nMarker | m     | Neutral particle's gyrocenter birth position in machine coordinates: gci([x,y,z],particle)|
-| `ri`                | `n_(p)npa > 1`| Float64 | 2    | 3, nMarker | m     | Neutral particle's birth position in machine coordinates: ri([x,y,z],particle)|
-| `rf`                | `n_(p)npa > 1`| Float64 | 2    | 3, nMarker | m     | Neutral particle's hit position in machine coordinates: rf([x,y,z],particle)|
+| `gci`               | `n_(p)npa > 1`| Float64 | 2    | 3, nMarker | cm     | Neutral particle's gyrocenter birth position in machine coordinates: gci([x,y,z],particle)|
+| `ri`                | `n_(p)npa > 1`| Float64 | 2    | 3, nMarker | cm     | Neutral particle's birth position in machine coordinates: ri([x,y,z],particle)|
+| `rf`                | `n_(p)npa > 1`| Float64 | 2    | 3, nMarker | cm     | Neutral particle's hit position in machine coordinates: rf([x,y,z],particle)|
 | `pitch`             | `n_(p)npa > 1`| Float64 | 1    | nMarker    | NA    | Pitch value of the neutral particle: p = v_parallel/v w.r.t. the magnetic field   |
 | `weight`            | `n_(p)npa > 1`| Float64 | 1    | nMarker    | #/s   | Neutral particle's contribution to the flux |
 

--- a/docs/user-guide/03_technical/index.md
+++ b/docs/user-guide/03_technical/index.md
@@ -3,3 +3,6 @@ title: Technical Details
 #Technical Details
 
 * [PREFIDA Inputs](./01_prefida_inputs.html)
+* [Troubleshooting](./02_trouble.html)
+* [Advance Settings](./03_advanced.html)
+* [Outputs](./04_outputs.html)

--- a/src/fidasim.f90
+++ b/src/fidasim.f90
@@ -3743,7 +3743,10 @@ subroutine read_f(fid, error)
         if(fbm%nphi.gt.1) then
             write(*,'(T2,"Phi  range = [",f5.2,",",f5.2,"]")') fbm%phimin,fbm%phimax
         endif
-        write(*,'(T2,"Ntotal = ",ES10.3)') fbm%n_tot
+        ! This fbm%n_tot is never caalculated not used, so it just print 0 in
+        ! the output file, which is quite confusing for the user, just comment 
+        ! this to avoid confusion
+        ! write(*,'(T2,"Ntotal = ",ES10.3)') fbm%n_tot
         write(*,*) ''
     endif
 


### PR DESCRIPTION
- Changed counter to int64 to avoid overflows issues
- Added gyrocenter positions to output file when `n_(p)npa > 1`
- Updated documentation

Please note that this modification alone does not allow to calculate INPA WF in orbit coordinates. This just make FIDASIM to output the needed data for the OWCF and FILDSIM codes to proceed with the actual calculation