### PR TITLE
have the maximum number to times a neutral/LOS can cross the plasma boundary be a user input

### DIFF
--- a/lib/idl/check_inputs.pro
+++ b/lib/idl/check_inputs.pro
@@ -38,13 +38,14 @@ PRO check_inputs, inputs
               calc_brems:zero_int, calc_birth:zero_int, calc_neutron:zero_int,$
               calc_cfpd:zero_int,calc_res:zero_int,$
               calc_fida_wght:zero_int, calc_npa_wght:zero_int, $
-              adaptive:zero_int, split_tol:zero_double, max_cell_splits:zero_int}
+              adaptive:zero_int, split_tol:zero_double, max_cell_splits:zero_int,$
+              max_crossings:zero_int}
     
     keys = tag_names(inputs)
     w = where(keys.capwords() eq 'ADAPTIVE')
     if w eq -1 then begin
         warn, 'Missing adaptive time step settings, defaulting to off'
-        inputs = create_struct(inputs, 'adaptive', 0, 'split_tol', double(0.0), 'max_cell_splits', 1)
+        inputs = create_struct(inputs, 'adaptive', 0, 'split_tol', double(0.0), 'max_cell_splits', 1, 'max_crossings', 2)
     endif
 
     check_struct_schema, schema, inputs, err_status, desc="simulation settings"
@@ -115,6 +116,12 @@ PRO check_inputs, inputs
     if inputs.max_cell_splits lt 1 then begin
       error,'Invalid max cell splits. Expected value >= 1'
       print,'max_cell_splits = ',inputs.max_cell_splits
+      err_status = 1
+    endif
+
+    if inputs.max_crossings lt 2 then begin
+      error,'Invalid max_crossings. Expected value >= 2'
+      print,'max_crossings = ',inputs.max_crossings
       err_status = 1
     endif
 

--- a/lib/idl/write_namelist.pro
+++ b/lib/idl/write_namelist.pro
@@ -117,6 +117,7 @@ PRO write_namelist, filename, inputs
     printf,55,f='("adaptive = ",i2,"    !! Adaptive switch, 0:split off, 1:dene, 2:denn, 3:denf, 4:deni, 5:denimp, 6:te, 7:ti")',inputs.adaptive
     printf,55,f='("split_tol = ",1f9.6,"    !! Tolerance for change in plasma parameter, number of cell splits is proportional to 1/split_tol")',inputs.split_tol
     printf,55,f='("max_cell_splits = ",i5,"    !! Maximum number of times a cell can be split")',inputs.max_cell_splits
+    printf,55,f='("max_crossings = ",i5,"    !! Maximum number of times a neutral/LOS can cross the plasma boundary")',inputs.max_crossings
     printf,55,''
     printf,55,'/'
     printf,55,''

--- a/lib/python/fidasim/preprocessing.py
+++ b/lib/python/fidasim/preprocessing.py
@@ -179,12 +179,14 @@ def check_inputs(inputs, use_abs_path=True):
               'calc_res': zero_int,
               'adaptive': zero_int,
               'split_tol': zero_double,
-              'max_cell_splits': zero_int}
+              'max_cell_splits': zero_int,
+              'max_crossings': zero_int}
 
     # If user doesn't provide adaptive time step parameters, set default to off
     inputs.setdefault('adaptive', 0)
     inputs.setdefault('split_tol', 0.0)
     inputs.setdefault('max_cell_splits', 1)
+    inputs.setdefault('max_crossings', 2)
 
     err = check_dict_schema(schema, inputs, desc="simulation settings")
     if err:
@@ -242,6 +244,11 @@ def check_inputs(inputs, use_abs_path=True):
     if (inputs['max_cell_splits'] < 1):
         error('Invalid max cell splits. Expected value >= 1')
         print('max_cell_splits = {}'.format(inputs['max_cell_splits']))
+        err = True
+
+    if (inputs['max_crossings'] < 2):
+        error('Invalid max_crossings. Expected value >= 2')
+        print('max_crossings = {}'.format(inputs['max_crossings']))
         err = True
 
     ps = os.path.sep
@@ -1408,6 +1415,7 @@ def write_namelist(filename, inputs):
         f.write("adaptive = {:d}    !! Adaptive switch, 0:split off, 1:dene, 2:denn, 3:denf, 4:deni, 5:denimp, 6:te, 7:ti\n".format(inputs['adaptive']))
         f.write("split_tol = {:f}    !! Tolerance for change in plasma parameter, number of cell splits is proportional to 1/split_tol\n".format(inputs['split_tol']))
         f.write("max_cell_splits = {:d}    !! Maximum number of times a cell can be split\n\n".format(inputs['max_cell_splits']))
+        f.write("max_crossings = {:d}    !! Maximum number of times a neutral/LOS can cross the plasma boundary\n\n".format(inputs['max_crossings']))
         f.write("/\n\n")
 
     success("Namelist file created: {}\n".format(filename))


### PR DESCRIPTION
This issue was brought up in Issue #289 The plasma equilibrium in tokamaks are usually convex, so it's usually safe to say that a neutral or a LOS can only cross the plasma boundary a maximum of twice. Once to enter the plasma and once to leave. For stellerators this is not the case. 

This PR introduces the `max_crossings` variable into the input namelist. The default is set to 2, but users should inspect their plasma boundary and increase it if necessary.